### PR TITLE
Missing dependency on bundler

### DIFF
--- a/README
+++ b/README
@@ -26,7 +26,7 @@ $ cd veewee
 $ . veewee.ENV
 
 1) Install all the necessary gems (sandboxes in $VEEWEE/gems)
-$ gem install rake vagrant popen4
+$ gem install rake vagrant popen4 bundler
 -> vagrant installs virtualbox,net-ssh, net-scp too
 
 2) List all templates


### PR DESCRIPTION
If you just:
gem install rake vagrant popen4
as written in the documentation, it fails:
$ rake templates
rake aborted!
no such file to load -- bundler

Maybe there is a better way to do so, but this one worked for me :)
