### PR TITLE
Fixes to the fedora templates

### DIFF
--- a/templates/Fedora-14-amd64-netboot/ks.cfg
+++ b/templates/Fedora-14-amd64-netboot/ks.cfg
@@ -24,6 +24,7 @@ logvol swap --fstype=swap --name=lv_swap --vgname=vg_main --size=528 --grow --ma
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_main --size=1024 --grow
 repo --name="Fedora 14 - x86_64"  --baseurl=http://mirrors.xmission.com/fedora/releases/14/Everything/x86_64/os/ --cost=1000
 repo --name="Fedora 14 - x86_64 - Updates"  --baseurl=http://mirror.pnl.gov/fedora/linux/updates/14/x86_64/ --cost=1000
+services --enabled network
 reboot
 
 %packages

--- a/templates/Fedora-14-amd64-netboot/postinstall.sh
+++ b/templates/Fedora-14-amd64-netboot/postinstall.sh
@@ -8,7 +8,9 @@ yum -y install gcc bzip2 make patch kernel-devel-`uname -r`
 
 yum -y install gcc-c++ zlib-devel openssl-devel readline-devel sqlite3-devel
 
-yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+# don't remove these because dependency removal will remove policycoreutils package and we should
+# not care about these packages being installed in the first place
+#yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
 
 
 yum -y clean all

--- a/templates/Fedora-14-amd64/ks.cfg
+++ b/templates/Fedora-14-amd64/ks.cfg
@@ -25,6 +25,7 @@ logvol / --fstype=ext4 --name=lv_root --vgname=vg_main --size=1024 --grow
 # We leave the repo commands out so that we install from the iso
 #repo --name="Fedora 14 - x86_64"  --baseurl=http://mirrors.xmission.com/fedora/releases/14/Everything/x86_64/os/ --cost=1000
 #repo --name="Fedora 14 - x86_64 - Updates"  --baseurl=http://mirror.pnl.gov/fedora/linux/updates/14/x86_64/ --cost=1000
+services --enabled network
 reboot
 
 %packages

--- a/templates/Fedora-14-amd64/postinstall.sh
+++ b/templates/Fedora-14-amd64/postinstall.sh
@@ -8,7 +8,9 @@ yum -y install gcc bzip2 make patch kernel-devel-`uname -r`
 
 yum -y install gcc-c++ zlib-devel openssl-devel readline-devel sqlite3-devel
 
-yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+# don't remove these because dependency removal will remove policycoreutils package and we should
+# not care about these packages being installed in the first place
+#yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
 
 
 yum -y clean all

--- a/templates/Fedora-14-i386-netboot/ks.cfg
+++ b/templates/Fedora-14-i386-netboot/ks.cfg
@@ -24,6 +24,7 @@ logvol swap --fstype=swap --name=lv_swap --vgname=vg_main --size=528 --grow --ma
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_main --size=1024 --grow
 repo --name="Fedora 14 - i386"  --baseurl=http://mirrors.xmission.com/fedora/releases/14/Everything/i386/os/ --cost=1000
 repo --name="Fedora 14 - i386 - Updates"  --baseurl=http://mirror.pnl.gov/fedora/linux/updates/14/i386/ --cost=1000
+services --enabled network
 reboot
 
 %packages

--- a/templates/Fedora-14-i386-netboot/postinstall.sh
+++ b/templates/Fedora-14-i386-netboot/postinstall.sh
@@ -8,7 +8,9 @@ yum -y install gcc bzip2 make patch kernel-devel-`uname -r`
 
 yum -y install gcc-c++ zlib-devel openssl-devel readline-devel sqlite3-devel
 
-yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+# don't remove these because dependency removal will remove policycoreutils package and we should
+# not care about these packages being installed in the first place
+#yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
 
 
 yum -y clean all

--- a/templates/Fedora-14-i386/ks.cfg
+++ b/templates/Fedora-14-i386/ks.cfg
@@ -25,6 +25,7 @@ logvol / --fstype=ext4 --name=lv_root --vgname=vg_main --size=1024 --grow
 # We leave the repo commands out so that we install from the iso
 #repo --name="Fedora 14 - i386"  --baseurl=http://mirrors.xmission.com/fedora/releases/14/Everything/i386/os/ --cost=1000
 #repo --name="Fedora 14 - i386 - Updates"  --baseurl=http://mirror.pnl.gov/fedora/linux/updates/14/i386/ --cost=1000
+services --enabled network
 reboot
 
 %packages

--- a/templates/Fedora-14-i386/postinstall.sh
+++ b/templates/Fedora-14-i386/postinstall.sh
@@ -8,7 +8,9 @@ yum -y install gcc bzip2 make patch kernel-devel-`uname -r`
 
 yum -y install gcc-c++ zlib-devel openssl-devel readline-devel sqlite3-devel
 
-yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+# don't remove these because dependency removal will remove policycoreutils package and we should
+# not care about these packages being installed in the first place
+#yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
 
 
 yum -y clean all


### PR DESCRIPTION
- update fedora templates to not remove corepolicyutils packages which breaks dracut + selinux
- ensure network service is enabled in ks.cfg
