### PR TITLE
Make Ruby / Rubygems-Version in postinstall.sh for Ubuntu more DRY

### DIFF
--- a/templates/ubuntu-10.04.2-server-amd64/postinstall.sh
+++ b/templates/ubuntu-10.04.2-server-amd64/postinstall.sh
@@ -20,14 +20,15 @@ apt-get -y install nfs-common
 # can install their own Rubies using packages or however.
 # We must install the 1.8.x series since Puppet doesn't support
 # Ruby 1.9 yet.
-wget http://ftp.ruby-lang.org/pub/ruby/ruby-1.8.7-p334.tar.gz
-tar xvzf ruby-1.8.7-p334.tar.gz
-cd ruby-1.8.7-p334
+VEEWEE_RUBY_VERSION="ruby-1.8.7-p334"
+wget http://ftp.ruby-lang.org/pub/ruby/${VEEWEE_RUBY_VERSION}.tar.gz
+tar xvzf ${VEEWEE_RUBY_VERSION}.tar.gz
+cd ${VEEWEE_RUBY_VERSION}
 ./configure --prefix=/opt/ruby
 make
 make install
 cd ..
-rm -rf ruby-1.8.7-p334*
+rm -rf ${VEEWEE_RUBY_VERSION}*
 
 # Install RubyGems 1.7.2
 VEEWEE_RUBYGEMS_VERSION="rubygems-1.7.2"

--- a/templates/ubuntu-10.04.2-server-i386/postinstall.sh
+++ b/templates/ubuntu-10.04.2-server-i386/postinstall.sh
@@ -20,14 +20,15 @@ apt-get -y install nfs-common
 # can install their own Rubies using packages or however.
 # We must install the 1.8.x series since Puppet doesn't support
 # Ruby 1.9 yet.
-wget http://ftp.ruby-lang.org/pub/ruby/ruby-1.8.7-p334.tar.gz
-tar xvzf ruby-1.8.7-p334.tar.gz
-cd ruby-1.8.7-p334
+VEEWEE_RUBY_VERSION="ruby-1.8.7-p334"
+wget http://ftp.ruby-lang.org/pub/ruby/${VEEWEE_RUBY_VERSION}.tar.gz
+tar xvzf ${VEEWEE_RUBY_VERSION}.tar.gz
+cd ${VEEWEE_RUBY_VERSION}
 ./configure --prefix=/opt/ruby
 make
 make install
 cd ..
-rm -rf ruby-1.8.7-p334*
+rm -rf ${VEEWEE_RUBY_VERSION}*
 
 # Install RubyGems 1.7.2
 VEEWEE_RUBYGEMS_VERSION="rubygems-1.7.2"

--- a/templates/ubuntu-10.10-server-amd64-netboot/postinstall.sh
+++ b/templates/ubuntu-10.10-server-amd64-netboot/postinstall.sh
@@ -20,14 +20,15 @@ apt-get -y install nfs-common
 # can install their own Rubies using packages or however.
 # We must install the 1.8.x series since Puppet doesn't support
 # Ruby 1.9 yet.
-wget http://ftp.ruby-lang.org/pub/ruby/ruby-1.8.7-p334.tar.gz
-tar xvzf ruby-1.8.7-p334.tar.gz
-cd ruby-1.8.7-p334
+VEEWEE_RUBY_VERSION="ruby-1.8.7-p334"
+wget http://ftp.ruby-lang.org/pub/ruby/${VEEWEE_RUBY_VERSION}.tar.gz
+tar xvzf ${VEEWEE_RUBY_VERSION}.tar.gz
+cd ${VEEWEE_RUBY_VERSION}
 ./configure --prefix=/opt/ruby
 make
 make install
 cd ..
-rm -rf ruby-1.8.7-p334*
+rm -rf ${VEEWEE_RUBY_VERSION}*
 
 # Install RubyGems 1.7.2
 VEEWEE_RUBYGEMS_VERSION="rubygems-1.7.2"

--- a/templates/ubuntu-10.10-server-amd64/postinstall.sh
+++ b/templates/ubuntu-10.10-server-amd64/postinstall.sh
@@ -20,14 +20,15 @@ apt-get -y install nfs-common
 # can install their own Rubies using packages or however.
 # We must install the 1.8.x series since Puppet doesn't support
 # Ruby 1.9 yet.
-wget http://ftp.ruby-lang.org/pub/ruby/ruby-1.8.7-p334.tar.gz
-tar xvzf ruby-1.8.7-p334.tar.gz
-cd ruby-1.8.7-p334
+VEEWEE_RUBY_VERSION="ruby-1.8.7-p334"
+wget http://ftp.ruby-lang.org/pub/ruby/${VEEWEE_RUBY_VERSION}.tar.gz
+tar xvzf ${VEEWEE_RUBY_VERSION}.tar.gz
+cd ${VEEWEE_RUBY_VERSION}
 ./configure --prefix=/opt/ruby
 make
 make install
 cd ..
-rm -rf ruby-1.8.7-p334*
+rm -rf ${VEEWEE_RUBY_VERSION}*
 
 # Install RubyGems 1.7.2
 VEEWEE_RUBYGEMS_VERSION="rubygems-1.7.2"

--- a/templates/ubuntu-10.10-server-i386-netboot/postinstall.sh
+++ b/templates/ubuntu-10.10-server-i386-netboot/postinstall.sh
@@ -20,14 +20,15 @@ apt-get -y install nfs-common
 # can install their own Rubies using packages or however.
 # We must install the 1.8.x series since Puppet doesn't support
 # Ruby 1.9 yet.
-wget http://ftp.ruby-lang.org/pub/ruby/ruby-1.8.7-p334.tar.gz
-tar xvzf ruby-1.8.7-p334.tar.gz
-cd ruby-1.8.7-p334
+VEEWEE_RUBY_VERSION="ruby-1.8.7-p334"
+wget http://ftp.ruby-lang.org/pub/ruby/${VEEWEE_RUBY_VERSION}.tar.gz
+tar xvzf ${VEEWEE_RUBY_VERSION}.tar.gz
+cd ${VEEWEE_RUBY_VERSION}
 ./configure --prefix=/opt/ruby
 make
 make install
 cd ..
-rm -rf ruby-1.8.7-p334*
+rm -rf ${VEEWEE_RUBY_VERSION}*
 
 # Install RubyGems 1.7.2
 VEEWEE_RUBYGEMS_VERSION="rubygems-1.7.2"

--- a/templates/ubuntu-10.10-server-i386/postinstall.sh
+++ b/templates/ubuntu-10.10-server-i386/postinstall.sh
@@ -20,14 +20,15 @@ apt-get -y install nfs-common
 # can install their own Rubies using packages or however.
 # We must install the 1.8.x series since Puppet doesn't support
 # Ruby 1.9 yet.
-wget http://ftp.ruby-lang.org/pub/ruby/ruby-1.8.7-p334.tar.gz
-tar xvzf ruby-1.8.7-p334.tar.gz
-cd ruby-1.8.7-p334
+VEEWEE_RUBY_VERSION="ruby-1.8.7-p334"
+wget http://ftp.ruby-lang.org/pub/ruby/${VEEWEE_RUBY_VERSION}.tar.gz
+tar xvzf ${VEEWEE_RUBY_VERSION}.tar.gz
+cd ${VEEWEE_RUBY_VERSION}
 ./configure --prefix=/opt/ruby
 make
 make install
 cd ..
-rm -rf ruby-1.8.7-p334*
+rm -rf ${VEEWEE_RUBY_VERSION}*
 
 # Install RubyGems 1.7.2
 VEEWEE_RUBYGEMS_VERSION="rubygems-1.7.2"

--- a/templates/ubuntu-11.04-server-amd64/postinstall.sh
+++ b/templates/ubuntu-11.04-server-amd64/postinstall.sh
@@ -20,14 +20,15 @@ apt-get -y install nfs-common
 # can install their own Rubies using packages or however.
 # We must install the 1.8.x series since Puppet doesn't support
 # Ruby 1.9 yet.
-wget http://ftp.ruby-lang.org/pub/ruby/ruby-1.8.7-p334.tar.gz
-tar xvzf ruby-1.8.7-p334.tar.gz
-cd ruby-1.8.7-p334
+VEEWEE_RUBY_VERSION="ruby-1.8.7-p334"
+wget http://ftp.ruby-lang.org/pub/ruby/${VEEWEE_RUBY_VERSION}.tar.gz
+tar xvzf ${VEEWEE_RUBY_VERSION}.tar.gz
+cd ${VEEWEE_RUBY_VERSION}
 ./configure --prefix=/opt/ruby
 make
 make install
 cd ..
-rm -rf ruby-1.8.7-p334*
+rm -rf ${VEEWEE_RUBY_VERSION}*
 
 # Install RubyGems 1.7.2
 VEEWEE_RUBYGEMS_VERSION="rubygems-1.7.2"

--- a/templates/ubuntu-11.04-server-i386/postinstall.sh
+++ b/templates/ubuntu-11.04-server-i386/postinstall.sh
@@ -20,14 +20,15 @@ apt-get -y install nfs-common
 # can install their own Rubies using packages or however.
 # We must install the 1.8.x series since Puppet doesn't support
 # Ruby 1.9 yet.
-wget http://ftp.ruby-lang.org/pub/ruby/ruby-1.8.7-p334.tar.gz
-tar xvzf ruby-1.8.7-p334.tar.gz
-cd ruby-1.8.7-p334
+VEEWEE_RUBY_VERSION="ruby-1.8.7-p334"
+wget http://ftp.ruby-lang.org/pub/ruby/${VEEWEE_RUBY_VERSION}.tar.gz
+tar xvzf ${VEEWEE_RUBY_VERSION}.tar.gz
+cd ${VEEWEE_RUBY_VERSION}
 ./configure --prefix=/opt/ruby
 make
 make install
 cd ..
-rm -rf ruby-1.8.7-p334*
+rm -rf ${VEEWEE_RUBY_VERSION}*
 
 # Install RubyGems 1.7.2
 VEEWEE_RUBYGEMS_VERSION="rubygems-1.7.2"


### PR DESCRIPTION
Hi Patrick,

I introduced two new shell for the Ruby / Rubygems-Version which speeds up the process of these two (=Timesaver).

Tested by calling "postinstall.sh" directly - worked as expected, no errors.

Cheers

Christian
