### PR TITLE
use Virtual box 4.0.8 ostype for Ubuntu (64 bit)

### DIFF
--- a/templates/ubuntu-11.04-server-amd64/definition.rb
+++ b/templates/ubuntu-11.04-server-amd64/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1', :memory_size=> '384', 
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
-  :os_type_id => 'Ubuntu64',
+  :os_type_id => 'Ubuntu_64',
   :iso_file => "ubuntu-11.04-server-amd64.iso",
   :iso_src => "http://releases.ubuntu.com/11.04/ubuntu-11.04-server-amd64.iso",
   :iso_md5 => "ce1cee108de737d7492e37069eed538e",


### PR DESCRIPTION
Not sure what the ostype is on other versions, but looks like on 4.0.8 it uses an underscore.

Veewee is _amazing_ to watch in action. Fantastic work man!

```
legolas:veewee cowboyd$ VBoxManage list ostypes | grep Ubuntu
ID:          Ubuntu
Description: Ubuntu
ID:          Ubuntu_64
Description: Ubuntu (64 bit)
```
