### PR TITLE
Incorrect OS Type for 64-bit Fedora

### DIFF
--- a/templates/Fedora-14-amd64-netboot/definition.rb
+++ b/templates/Fedora-14-amd64-netboot/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1', :memory_size=> '384',
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :hwvirtext => 'on',
-  :os_type_id => 'Fedora',
+  :os_type_id => 'Fedora_64',
   :iso_file => "Fedora-14-x86_64-netinst.iso",
   :iso_src => "http://mirror.uoregon.edu/fedora/linux/releases/14/Fedora/x86_64/iso/Fedora-14-x86_64-netinst.iso",
   :iso_md5 => "acd25fc1470f2497cf2a2a245adbfe1e",


### PR DESCRIPTION
When building this image, it will immediately halt and say it is an incorrect processor. (i686 instead of x86_64)

This change fixed it for me
