### PR TITLE
Fixed rubyfile path, cut'n'paste error?

### DIFF
--- a/templates/ubuntu-10.04.2-server-amd64/postinstall.sh
+++ b/templates/ubuntu-10.04.2-server-amd64/postinstall.sh
@@ -21,7 +21,7 @@ apt-get -y install nfs-common
 # We must install the 1.8.x series since Puppet doesn't support
 # Ruby 1.9 yet.
 wget http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.gz
-tar xvzf http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.gz
+tar xvzf ruby-1.8.7-p334.tar.gz
 cd ruby-1.8.7-p334
 ./configure --prefix=/opt/ruby
 make


### PR DESCRIPTION
The untaring of ruby failed in this version of the template, upon closer inspection tar tries to untar the full URL path, not the filename.
