### PR TITLE
Allow VEEWEE_SSH_PORT to override default SSH port in cucumber features.

### DIFF
--- a/validation/features/steps/ssh_steps.rb
+++ b/validation/features/steps/ssh_steps.rb
@@ -63,7 +63,7 @@ When /^I ssh to "([^\"]*)" with the following credentials:$/ do |hostname, table
     session_keys << session["keyfile"]
     session_auth_methods << "publickey"
   end
-  session_port=22
+  session_port = ENV['VEEWEE_SSH_PORT'] || 22
   if session["port"]
      session_port=session["port"]  
   end

--- a/validation/vagrant.feature
+++ b/validation/vagrant.feature
@@ -4,49 +4,49 @@ Feature: vagrant box validation
 
 Scenario: Checking login
 	When I ssh to "127.0.0.1" with the following credentials: 
-	| username| password | port |
-	| vagrant | vagrant  | 7222 |
+	| username| password |
+	| vagrant | vagrant  |
 	And I run "whoami"
 	Then I should see "vagrant" in the output
 
 Scenario: Checking sudo
 	When I ssh to "127.0.0.1" with the following credentials: 
-	| username| password | port |
-	| vagrant | vagrant  | 7222 |
+	| username| password |
+	| vagrant | vagrant  |
 	And I run "sudo whoami"
 	Then I should see "root" in the output
 
 Scenario: Checking ruby
 	When I ssh to "127.0.0.1" with the following credentials: 
-	| username| password | port |
-	| vagrant | vagrant  | 7222 |
+	| username| password |
+	| vagrant | vagrant  |
 	And I run ". /etc/profile ;ruby --version 2> /dev/null 1> /dev/null;  echo $?"
 	Then I should see "0" in the output
 
 Scenario: Checking gem
 	When I ssh to "127.0.0.1" with the following credentials: 
-	| username| password | port |
-	| vagrant | vagrant  | 7222 |
+	| username| password |
+	| vagrant | vagrant  |
 	And I run ". /etc/profile; gem --version 2> /dev/null 1> /dev/null ; echo $?"
 	Then I should see "0" in the output
 
 Scenario: Checking chef
 	When I ssh to "127.0.0.1" with the following credentials: 
-	| username| password | port |
-	| vagrant | vagrant  | 7222 |
+	| username| password |
+	| vagrant | vagrant  |
 	And I run ". /etc/profile ;chef-client --version 2> /dev/null 1>/dev/null; echo $?"
 	Then I should see "0" in the output
 
 Scenario: Checking puppet
 	When I ssh to "127.0.0.1" with the following credentials: 
-	| username| password | port |
-	| vagrant | vagrant  | 7222 |
+	| username| password |
+	| vagrant | vagrant  |
 	And I run ". /etc/profile ; puppet --version 2> /dev/null 1>/dev/null; echo $?"
 	Then I should see "0" in the output
 
 Scenario: Checking shared folders
 	When I ssh to "127.0.0.1" with the following credentials: 
-	| username| password |keyfile  | port |
-	| vagrant | vagrant  | vagrant-private.key | 7222 |
+	| username| password |keyfile  |
+	| vagrant | vagrant  | vagrant-private.key |
 	And I run "mount|grep veewee-validation"
 	Then I should see "veewee-validation" in the output


### PR DESCRIPTION
The environment variable could be changed around if there are other veewee conventions or this value could be passed in as a CLI flag.
