### PR TITLE
curl option to honor redirects

### DIFF
--- a/templates/Debian-6.0.2-i386-netboot/postinstall.sh
+++ b/templates/Debian-6.0.2-i386-netboot/postinstall.sh
@@ -32,7 +32,7 @@ gem install puppet --no-ri --no-rdoc
 mkdir -p /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-curl -o /home/vagrant/.ssh/authorized_keys \
+curl -Lo /home/vagrant/.ssh/authorized_keys \
   'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub'
 chmod 0600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant:vagrant /home/vagrant/.ssh


### PR DESCRIPTION
when requesting Vagrant ssh key. This is only needed in Debian-6.0.2-i386-netboot template.

BTW, this is not consistant -- some templates use `wget`, while others use `curl`
