### PR TITLE
Set port count for new SATA controllers to 1

### DIFF
--- a/lib/veewee/session.rb
+++ b/lib/veewee/session.rb
@@ -639,7 +639,7 @@ module Veewee
 
     def self.add_sata_controller(boxname)
       #unless => "${vboxcmd} showvminfo '${vname}' | grep 'SATA Controller' ";
-      command ="#{@vboxcmd} storagectl '#{boxname}' --name 'SATA Controller' --add sata --hostiocache #{@definition[:hostiocache]}"
+      command ="#{@vboxcmd} storagectl '#{boxname}' --name 'SATA Controller' --add sata --sataportcount 1 --hostiocache #{@definition[:hostiocache]}"
       Veewee::Shell.execute("#{command}")
     end
 


### PR DESCRIPTION
The default port count for new SATA controllers is 30. This increases the
boot time for CentOS (and possibly other) VMs while each port is probed for a
disk. Currently veewee only ever adds one disk to port 0 of the SATA
controller and Vagrant doesn't support the automatic attachment of disks to
a box during `vagrant up`, so it should be safe to reduce this to 1.

This may need to be incremented if #86 is implemented or configurable if
feature 334 is implemented in Vagrant.
