### PR TITLE
fixed a bug with ssh pubkey grabbed by postinstall.sh

### DIFF
--- a/templates/CentOS-4.8-i386/postinstall.sh
+++ b/templates/CentOS-4.8-i386/postinstall.sh
@@ -30,7 +30,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/CentOS-5.5-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-5.5-x86_64-netboot/postinstall.sh
@@ -39,7 +39,7 @@ echo "Installing chef and puppet"
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/CentOS-5.6-i386-netboot/postinstall.sh
+++ b/templates/CentOS-5.6-i386-netboot/postinstall.sh
@@ -31,7 +31,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/CentOS-5.6-i386/postinstall.sh
+++ b/templates/CentOS-5.6-i386/postinstall.sh
@@ -30,7 +30,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/CentOS-5.6-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-5.6-x86_64-netboot/postinstall.sh
@@ -39,7 +39,7 @@ echo "Installing chef and puppet"
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/CentOS-5.7-i386-netboot/postinstall.sh
+++ b/templates/CentOS-5.7-i386-netboot/postinstall.sh
@@ -32,7 +32,7 @@ ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/CentOS-5.7-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-5.7-x86_64-netboot/postinstall.sh
@@ -39,7 +39,7 @@ echo "Installing chef and puppet"
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/CentOS-6.0-i386-netboot/postinstall.sh
+++ b/templates/CentOS-6.0-i386-netboot/postinstall.sh
@@ -11,7 +11,7 @@ gem install --no-ri --no-rdoc chef
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 # Installing the virtualbox guest additions

--- a/templates/CentOS-6.0-i386/postinstall.sh
+++ b/templates/CentOS-6.0-i386/postinstall.sh
@@ -29,7 +29,7 @@ gem install --no-ri --no-rdoc chef
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 # Installing the virtualbox guest additions

--- a/templates/CentOS-6.0-x86_64-minimal/postinstall.sh
+++ b/templates/CentOS-6.0-x86_64-minimal/postinstall.sh
@@ -30,7 +30,7 @@ gem install --no-ri --no-rdoc chef
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-curl -L -o authorized_keys http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub
+curl -L -o authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 chown -R vagrant /home/vagrant/.ssh
 
 # Installing the virtualbox guest additions

--- a/templates/CentOS-6.0-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-6.0-x86_64-netboot/postinstall.sh
@@ -11,7 +11,7 @@ gem install --no-ri --no-rdoc chef
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 # Installing the virtualbox guest additions

--- a/templates/CentOS-6.0-x86_64/postinstall.sh
+++ b/templates/CentOS-6.0-x86_64/postinstall.sh
@@ -29,7 +29,7 @@ gem install --no-ri --no-rdoc chef
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 # Installing the virtualbox guest additions

--- a/templates/Debian-5.0.8-amd64-netboot/postinstall.sh
+++ b/templates/Debian-5.0.8-amd64-netboot/postinstall.sh
@@ -30,7 +30,7 @@ ln -sfv /usr/bin/gem1.8 /usr/bin/gem
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/Debian-5.0.8-i386-netboot/postinstall.sh
+++ b/templates/Debian-5.0.8-i386-netboot/postinstall.sh
@@ -30,7 +30,7 @@ ln -sfv /usr/bin/gem1.8 /usr/bin/gem
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/Debian-6.0.2-amd64-netboot/postinstall.sh
+++ b/templates/Debian-6.0.2-amd64-netboot/postinstall.sh
@@ -28,7 +28,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/Debian-6.0.2-i386-netboot/postinstall.sh
+++ b/templates/Debian-6.0.2-i386-netboot/postinstall.sh
@@ -33,7 +33,7 @@ mkdir -p /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
 curl -Lo /home/vagrant/.ssh/authorized_keys \
-  'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub'
+  'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
 chmod 0600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant:vagrant /home/vagrant/.ssh
 

--- a/templates/Fedora-14-amd64-netboot/postinstall.sh
+++ b/templates/Fedora-14-amd64-netboot/postinstall.sh
@@ -33,7 +33,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/Fedora-14-amd64/postinstall.sh
+++ b/templates/Fedora-14-amd64/postinstall.sh
@@ -33,7 +33,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/Fedora-14-i386-netboot/postinstall.sh
+++ b/templates/Fedora-14-i386-netboot/postinstall.sh
@@ -33,7 +33,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/Fedora-14-i386/postinstall.sh
+++ b/templates/Fedora-14-i386/postinstall.sh
@@ -33,7 +33,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/archlinux-i386-netboot/postinstall.sh
+++ b/templates/archlinux-i386-netboot/postinstall.sh
@@ -51,7 +51,7 @@ sed -i 's:^DAEMONS\(.*\))$:DAEMONS\1 sshd):' /etc/rc.conf
 # install mitchellh's ssh key
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/archlinux-i386/postinstall.sh
+++ b/templates/archlinux-i386/postinstall.sh
@@ -52,7 +52,7 @@ sed -i 's:^DAEMONS\(.*\))$:DAEMONS\1 sshd):' /etc/rc.conf
 # install mitchellh's ssh key
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/archlinux-x86_64-netboot/postinstall.sh
+++ b/templates/archlinux-x86_64-netboot/postinstall.sh
@@ -54,7 +54,7 @@ sed -i 's:^DAEMONS\(.*\))$:DAEMONS\1 sshd):' /etc/rc.conf
 # install mitchellh's ssh key
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/archlinux-x86_64/postinstall.sh
+++ b/templates/archlinux-x86_64/postinstall.sh
@@ -54,7 +54,7 @@ sed -i 's:^DAEMONS\(.*\))$:DAEMONS\1 sshd):' /etc/rc.conf
 # install mitchellh's ssh key
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/freebsd-8.2-pcbsd-i386-netboot/postinstall.sh
+++ b/templates/freebsd-8.2-pcbsd-i386-netboot/postinstall.sh
@@ -32,7 +32,7 @@ make install -DBATCH
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-/usr/local/bin/wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+/usr/local/bin/wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 # Cleaning portstree to save space

--- a/templates/freebsd-8.2-pcbsd-i386/postinstall.sh
+++ b/templates/freebsd-8.2-pcbsd-i386/postinstall.sh
@@ -32,7 +32,7 @@ make install -DBATCH
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-/usr/local/bin/wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+/usr/local/bin/wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 # Cleaning portstree to save space

--- a/templates/gentoo-latest-i386-experimental/postinstall.sh
+++ b/templates/gentoo-latest-i386-experimental/postinstall.sh
@@ -135,7 +135,7 @@ echo "creating vagrant ssh keys"
 chroot /mnt/gentoo mkdir /home/vagrant/.ssh
 chroot /mnt/gentoo chmod 700 /home/vagrant/.ssh
 chroot /mnt/gentoo cd /home/vagrant/.ssh
-chroot /mnt/gentoo wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chroot /mnt/gentoo wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
 chroot /mnt/gentoo chmod 600 /home/vagrant/.ssh/authorized_keys
 chroot /mnt/gentoo chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/openSUSE-11.4-DVD-i586/postinstall.sh
+++ b/templates/openSUSE-11.4-DVD-i586/postinstall.sh
@@ -8,7 +8,7 @@ date > /etc/vagrant_box_build_time
 echo -e "\ninstall vagrant key ..."
 mkdir -m 0700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate -O authorized_keys http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub
+wget --no-check-certificate -O authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 chmod 0600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant.users /home/vagrant/.ssh
 

--- a/templates/openSUSE-11.4-DVD-x86_64/postinstall.sh
+++ b/templates/openSUSE-11.4-DVD-x86_64/postinstall.sh
@@ -8,7 +8,7 @@ date > /etc/vagrant_box_build_time
 echo -e "\ninstall vagrant key ..."
 mkdir -m 0700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate -O authorized_keys http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub
+wget --no-check-certificate -O authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 chmod 0600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant.users /home/vagrant/.ssh
 

--- a/templates/openSUSE-11.4-NET-i586/postinstall.sh
+++ b/templates/openSUSE-11.4-NET-i586/postinstall.sh
@@ -8,7 +8,7 @@ date > /etc/vagrant_box_build_time
 echo -e "\ninstall vagrant key ..."
 mkdir -m 0700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate -O authorized_keys http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub
+wget --no-check-certificate -O authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 chmod 0600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant.users /home/vagrant/.ssh
 

--- a/templates/openSUSE-11.4-NET-x86_64/postinstall.sh
+++ b/templates/openSUSE-11.4-NET-x86_64/postinstall.sh
@@ -8,7 +8,7 @@ date > /etc/vagrant_box_build_time
 echo -e "\ninstall vagrant key ..."
 mkdir -m 0700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate -O authorized_keys http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub
+wget --no-check-certificate -O authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 chmod 0600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant.users /home/vagrant/.ssh
 

--- a/templates/openindiana-148-ai-x86/postinstall.sh
+++ b/templates/openindiana-148-ai-x86/postinstall.sh
@@ -56,7 +56,7 @@ export PATH=/opt/csw/gcc4/bin:$PATH
 mkdir /export/home/vagrant/.ssh
 chmod 700 /export/home/vagrant/.ssh
 cd /export/home/vagrant/.ssh
-/usr/bin/wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+/usr/bin/wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /export/home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/opensuse-11.4-i386-experimental/postinstall.sh
+++ b/templates/opensuse-11.4-i386-experimental/postinstall.sh
@@ -31,7 +31,7 @@ zypper --non-interactive install wget
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/solaris-11-express-i386/postinstall.sh
+++ b/templates/solaris-11-express-i386/postinstall.sh
@@ -55,7 +55,7 @@ export PATH=/opt/csw/gcc4/bin:$PATH
 mkdir /export/home/vagrant/.ssh
 chmod 700 /export/home/vagrant/.ssh
 cd /export/home/vagrant/.ssh
-/usr/bin/wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+/usr/bin/wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /export/home/vagrant/.ssh
 
 #Installing the virtualbox guest additions

--- a/templates/ubuntu-10.04.2-amd64-netboot/postinstall.sh
+++ b/templates/ubuntu-10.04.2-amd64-netboot/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-10.04.2-server-i386-netboot/postinstall.sh
+++ b/templates/ubuntu-10.04.2-server-i386-netboot/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-10.04.3-server-amd64-alt/postinstall.sh
+++ b/templates/ubuntu-10.04.3-server-amd64-alt/postinstall.sh
@@ -190,7 +190,7 @@ if test ! -d "${DIR_PATH}" ; then
 fi
 chmod 700 /home/${VEEWEE_USER}/.ssh
 cd /home/${VEEWEE_USER}/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 0600  /home/${VEEWEE_USER}/.ssh/*
 chown -R ${VEEWEE_USER} /home/${VEEWEE_USER}/.ssh
 cp /etc/ssh/sshd_config /etc/ssh/sshd_config.original

--- a/templates/ubuntu-10.04.3-server-amd64/postinstall.sh
+++ b/templates/ubuntu-10.04.3-server-amd64/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-10.04.3-server-i386/postinstall.sh
+++ b/templates/ubuntu-10.04.3-server-i386/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-10.10-server-amd64-netboot/postinstall.sh
+++ b/templates/ubuntu-10.10-server-amd64-netboot/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-10.10-server-amd64/postinstall.sh
+++ b/templates/ubuntu-10.10-server-amd64/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-10.10-server-i386-netboot/postinstall.sh
+++ b/templates/ubuntu-10.10-server-i386-netboot/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-10.10-server-i386/postinstall.sh
+++ b/templates/ubuntu-10.10-server-i386/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-11.04-server-amd64/postinstall.sh
+++ b/templates/ubuntu-11.04-server-amd64/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-11.04-server-i386/postinstall.sh
+++ b/templates/ubuntu-11.04-server-i386/postinstall.sh
@@ -51,7 +51,7 @@ echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-8.04.4-server-amd64/postinstall.sh
+++ b/templates/ubuntu-8.04.4-server-amd64/postinstall.sh
@@ -28,7 +28,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/ubuntu-8.04.4-server-i386/postinstall.sh
+++ b/templates/ubuntu-8.04.4-server-i386/postinstall.sh
@@ -28,7 +28,7 @@ rm ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 

--- a/templates/windows-2008R2-amd64/postinstall.sh
+++ b/templates/windows-2008R2-amd64/postinstall.sh
@@ -7,7 +7,7 @@ cd /home/vagrant
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-wget --no-check-certificate 'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' -O authorized_keys
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 cd ..
 


### PR DESCRIPTION
It looks like github recently changed their url structure for raw files. It now uses a subdomain (raw.github.com) vs the old way of github.com/raw/... I have updated all of the templates postinstall.sh to point to the new url.
