### PR TITLE
Centos 6 minimal was missing VBOX_VERSION

### DIFF
--- a/templates/CentOS-6.0-x86_64-minimal/postinstall.sh
+++ b/templates/CentOS-6.0-x86_64-minimal/postinstall.sh
@@ -34,6 +34,7 @@ curl -L -o authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/
 chown -R vagrant /home/vagrant/.ssh
 
 # Installing the virtualbox guest additions
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
 cd /tmp
 curl -L -o VBoxGuestAdditions_$VBOX_VERSION.iso http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso
 mount -o loop VBoxGuestAdditions_$VBOX_VERSION.iso /mnt


### PR DESCRIPTION
The template for centos6 was missing the assignment of the VBOX_VERSION var, causing the last validate feature to fail.  I also verified that the other Centos templates had the assignment.
