### PR TITLE
puppet and chef not being installed,

### DIFF
--- a/templates/CentOS-5.7-i386-netboot/postinstall.sh
+++ b/templates/CentOS-5.7-i386-netboot/postinstall.sh
@@ -25,8 +25,8 @@ ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 
 #Installing chef & Puppet
-/opt/ruby/bin/gem install chef --no-ri --no-rdoc
-/opt/ruby/bin/gem install puppet --no-ri --no-rdoc
+/usr/bin/gem install chef --no-ri --no-rdoc
+/usr/bin/gem install puppet --no-ri --no-rdoc
 
 #Installing vagrant keys
 mkdir /home/vagrant/.ssh


### PR DESCRIPTION
modified postinstall.sh paths /opt/ruby/bin/gem instead of /usr/bin/gem

  postinstall.sh: line 28: /opt/ruby/bin/gem: No such file or directory
  postinstall.sh: line 29: /opt/ruby/bin/gem: No such file or directory
