### PR TITLE
MD5 Was wrong for Ubuntu 11.04 i386 Template.  

### DIFF
--- a/templates/ubuntu-11.04-server-i386/definition.rb
+++ b/templates/ubuntu-11.04-server-i386/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :os_type_id => 'Ubuntu',
   :iso_file => "ubuntu-11.04-server-i386.iso",
   :iso_src => "http://releases.ubuntu.com/11.04/ubuntu-11.04-server-i386.iso",
-  :iso_md5 => "ce1cee108de737d7492e37069eed538e",
+  :iso_md5 => "b1a479c6593a90029414d201cb83a9cc",
   :iso_download_timeout => "1000",
   :boot_wait => "10", :boot_cmd_sequence => [
     '<Esc><Esc><Enter>',


### PR DESCRIPTION
While building a box it was noticed that the md5 was wrong for this template. Here is the output below of the true md5sum. 

densone@dev:~/veewee/iso$ md5sum ubuntu-11.04-server-i386.iso 
b1a479c6593a90029414d201cb83a9cc  ubuntu-11.04-server-i386.iso
densone@dev:~/veewee/iso$ 
