### PR TITLE
Allow user to specify vagrantfile and included files.

### DIFF
--- a/lib/veewee/export.rb
+++ b/lib/veewee/export.rb
@@ -53,7 +53,8 @@ module Veewee
       export_command += " --vagrantfile '#{definition[:vagrantfile]}'" if definition[:vagrantfile]
 
       include_files = [definition[:include_files]].flatten.compact
-      export_command += " --include #{include_files.join(' ')}"
+      include_files.map! { |filename| "'#{filename}'" }
+      export_command += " --include #{include_files.join(' ')}" unless include_files.empty?
 
       puts export_command
       Veewee::Shell.execute(export_command) #hmm, needs to get the gem_home set?


### PR DESCRIPTION
Added ability to process `:vagrantfile` and `:include_files` defined in definition.rb

For example:

``` ruby
# work/definitions/boxname/definition.rb
Veewee::Session.declare({
  :vagrantfile => File.expand_path('../Vagrantfile.pkg', __FILE__),
  :include_files => 'file1' # or ['file1', 'file2']
})
```

where Vagrantfile.pkg is in work/definitions/boxname/ and file1 is in work/.
