### PR TITLE
fresh temp dir

### DIFF
--- a/lib/veewee/session.rb
+++ b/lib/veewee/session.rb
@@ -533,7 +533,7 @@ module Veewee
         # Check for floppy
         unless @definition[:floppy_files].nil?
             require 'tmpdir'
-            temp_dir=Dir.tmpdir
+            temp_dir=Dir.mktmpdir
             @definition[:floppy_files].each do |filename|
               full_filename=full_filename=File.join(@definition_dir,boxname,filename)
               FileUtils.cp("#{full_filename}","#{temp_dir}")


### PR DESCRIPTION
In the command line for dir2floppy.jar, the tmp dir should start out empty and NOT be '/tmp'

```
 vagrant basebox build win2008

Verifying the isofile 7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso is ok.
java -jar /usr/local/rvm/gems/ruby-1.9.2-p180@tv/bundler/gems/veewee-c2c1a3dfef76/lib/java/dir2floppy.jar '/tmp/d20111212-32700-1dwk8xe'
 '/home/chris/telogis/vagrant/definitions/win2008/virtualfloppy.vfd'                                                                   
VBoxManage storagectl 'win2008' --name 'Floppy Controller' --add floppy
VBoxManage storageattach 'win2008' --storagectl 'Floppy Controller' --port 0 --device 0 --type fdd --medium '/home/chris/telogis/vagrant
/definitions/win2008/virtualfloppy.vfd'                                                                                                
Creating vm win2008 : 384M - 1 CPU - Windows2008_64
```

Right now it pulls everything in from '/tmp' rather than creating a fresh tmp directory and copying the correct files in. With this change it acts as expected, and windows actually installs. ;)
