### PR TITLE
Add template for CentOS 6.1 x86_64 minimal.

### DIFF
--- a/templates/CentOS-6.1-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.1-x86_64-minimal/definition.rb
@@ -1,0 +1,15 @@
+Veewee::Session.declare({
+  :cpu_count => '1', :memory_size=> '512',
+  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :os_type_id => 'RedHat_64',
+  :iso_file => "CentOS-6.1-x86_64-minimal.iso", :iso_src => "http://mirror.internode.on.net/pub/centos/6.1/isos/x86_64/CentOS-6.1-x86_64-minimal.iso", :iso_md5 => "03177dfefb4ebfeb03f457c29f00b0a1", :iso_download_timeout => 1000,
+  :boot_wait => "10", :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122", :kickstart_timeout => 10000, :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "100", :ssh_user => "vagrant", :ssh_password => "vagrant", :ssh_key => "",
+  :ssh_host_port => "7222", :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [ "postinstall.sh"], :postinstall_timeout => 10000
+})

--- a/templates/CentOS-6.1-x86_64-minimal/ks.cfg
+++ b/templates/CentOS-6.1-x86_64-minimal/ks.cfg
@@ -1,0 +1,37 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@core
+bzip2
+
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+
+%post
+/usr/bin/yum -y install sudo
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant		ALL=(ALL)		NOPASSWD: ALL" >> /etc/sudoers

--- a/templates/CentOS-6.1-x86_64-minimal/postinstall.sh
+++ b/templates/CentOS-6.1-x86_64-minimal/postinstall.sh
@@ -1,0 +1,50 @@
+#http://chrisadams.me.uk/2010/05/10/setting-up-a-centos-base-box-for-development-and-testing-with-vagrant/
+
+date > /etc/vagrant_box_build_time
+
+yum -y install gcc make gcc-c++ ruby kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=http://download.fedoraproject.org/pub/epel/6/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter ruby-devel rubygems
+yum -y clean all
+rm /etc/yum.repos.d/{puppetlabs,epel}.repo
+
+gem install --no-ri --no-rdoc chef
+
+# Installing vagrant keys
+mkdir /home/vagrant/.ssh
+chmod 700 /home/vagrant/.ssh
+cd /home/vagrant/.ssh
+curl -L -o authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
+chown -R vagrant /home/vagrant/.ssh
+
+# Installing the virtualbox guest additions
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+cd /tmp
+curl -L -o VBoxGuestAdditions_$VBOX_VERSION.iso http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso
+mount -o loop VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+
+rm VBoxGuestAdditions_$VBOX_VERSION.iso
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+dd if=/dev/zero of=/tmp/clean || rm /tmp/clean
+
+exit


### PR DESCRIPTION
Notably, it seems to require more RAM than 6.0 so I've bumped it up to 512MB.

There also seems to be no good standard for ISO sources (or even whether they are downloaded automatically or not, which some people disable) so I've used one close to me even though it feels dirty. An ISO "fastestmirror" equivalent would be handy but should be the subject of later work.
