### PR TITLE
Update gentoo template with valid URLs & options

### DIFF
--- a/templates/gentoo-latest-x86_64-experimental/definition.rb
+++ b/templates/gentoo-latest-x86_64-experimental/definition.rb
@@ -1,10 +1,10 @@
 Veewee::Session.declare( {
-  :cpu_count => '8', :memory_size=> '2048',
+  :cpu_count => '2', :memory_size=> '1024',
   :disk_size => '10140', :disk_format => 'VDI',:hostiocache => 'off',
   :os_type_id => 'Gentoo',
-  :iso_file => "install-amd64-minimal-20111013.iso",
-  :iso_src => "http://mirror.switch.ch/ftp/mirror/gentoo/releases/amd64/autobuilds/20111013/install-amd64-minimal-20111013.iso",
-  :iso_md5 => "3a08f6c41b7ba1a7574fed14629778c9",
+  :iso_file => "install-amd64-minimal-20111208.iso",
+  :iso_src => "http://distfiles.gentoo.org/releases/amd64/autobuilds/current-iso/install-amd64-minimal-20111208.iso",
+  :iso_md5 => "8c4e10aaaa7cce35503c0d23b4e0a42a",
   :iso_download_timeout => "1000",
   :boot_wait => "1",:boot_cmd_sequence => [
         '<Wait>'*2,

--- a/templates/gentoo-latest-x86_64-experimental/postinstall.sh
+++ b/templates/gentoo-latest-x86_64-experimental/postinstall.sh
@@ -44,7 +44,7 @@ cd /mnt/gentoo
 
 #Download a stage3 archive
 while true; do
-	wget http://mirror.switch.ch/ftp/mirror/gentoo/releases/amd64/autobuilds/20111013/stage3-amd64-20111013.tar.bz2 && > gotstage3
+        wget http://distfiles.gentoo.org/releases/amd64/current-stage3/stage3-amd64-20111208.tar.bz2 && > gotstage3
         if [ -f "gotstage3" ]
         then
 		break
@@ -58,7 +58,7 @@ tar xjpf stage3*
 #Download Portage snapshot
 cd /mnt/gentoo/usr
 while true; do
-	wget http://mirror.switch.ch/ftp/mirror/gentoo/snapshots/portage-latest.tar.bz2 && > gotportage
+        wget http://distfiles.gentoo.org/releases/snapshots/current/portage-latest.tar.bz2 && > gotportage
         if [ -f "gotportage" ]
         then
 		break


### PR DESCRIPTION
Existing gentoo-x86_64 template was borked with bad URLs, etc.

These changes include:
- Update `:iso_src` to valid URL of current image
- Also update `:iso_file` to correspond with this change.
- Update to valid stage3 and portage URLs to download
- Reduce `:cpu_count` and `:memory_size` to more reasonable default values
  (2 and 1024 respectively)
