### PR TITLE
Setup validation_dir in environment and pass options to Session.build().

### DIFF
--- a/bin/veewee
+++ b/bin/veewee
@@ -13,7 +13,7 @@ definition_dir= File.expand_path(File.join(".", "definitions"))
 lib_dir= File.expand_path(File.join(veewee_dir, "lib"))
 box_dir= File.expand_path(File.join(veewee_dir, "boxes"))
 template_dir=File.expand_path(File.join(veewee_dir, "templates"))
-
+validation_dir=File.expand_path(File.join(veewee_dir, "validation"))
 #vbox_dir=File.expand_path(File.join(veewee_dir, "tmp"))
 tmp_dir=File.expand_path(File.join(veewee_dir, "tmp"))
 
@@ -27,8 +27,15 @@ Dir.glob(File.join(lib_dir, '**','*.rb')).each {|f|
   require f  }
 
 #Initialize
-Veewee::Session.setenv({:veewee_dir => veewee_dir, :definition_dir => definition_dir,
-   :template_dir => template_dir, :iso_dir => iso_dir, :box_dir => box_dir, :tmp_dir => tmp_dir})
+Veewee::Session.setenv({
+                         :veewee_dir => veewee_dir, 
+                         :definition_dir => definition_dir,
+                         :validation_dir => validation_dir,
+                         :template_dir => template_dir, 
+                         :iso_dir => iso_dir, 
+                         :box_dir => box_dir, 
+                         :tmp_dir => tmp_dir,
+                       })
 
 
    
@@ -56,7 +63,7 @@ class VeeweeCLI < Thor
   method_options :force => :boolean
   def build(boxname)
     puts "Building box #{boxname}"
-	  Veewee::Session.build(boxname)
+	  Veewee::Session.build(boxname, options)
   end
 
   desc "export [NAME]", "export the box" 


### PR DESCRIPTION
This makes bin/veewee work for me; otherwise, it crashes when you try to build or init.
