### PR TITLE
Remove extra command execution in Session.create_vm().

### DIFF
--- a/lib/veewee/session.rb
+++ b/lib/veewee/session.rb
@@ -556,10 +556,6 @@ module Veewee
 
         end
 
-
-        #Exec and system stop the execution here
-        Veewee::Shell.execute("#{command}")
-
         command="#{@vboxcmd} sharedfolder add  '#{boxname}' --name 'veewee-validation' --hostpath '#{File.expand_path(@validation_dir)}' --automount"
 
         Veewee::Shell.execute("#{command}")


### PR DESCRIPTION
create_vm executes one of the set VM flag commands twice by mistake. This patch removes the extra command execution.
