### PR TITLE
Add an option to configure the NAT network

### DIFF
--- a/lib/veewee/session.rb
+++ b/lib/veewee/session.rb
@@ -527,6 +527,13 @@ module Veewee
           end
         end
 
+        # Set NAT network
+        unless @definition[:network].nil?
+          puts "Using #{@definition[:network]} as the NAT network"
+          command="#{@vboxcmd} modifyvm #{boxname} --natnet1 #{@definition[:network]}"
+          Veewee::Shell.execute("#{command}")
+        end
+
         # Todo Check for java
         # Todo check output of commands
 
@@ -670,7 +677,6 @@ module Veewee
       command ="#{@vboxcmd} storageattach '#{boxname}' --storagectl 'IDE Controller' --type dvddrive --port 1 --device 0 --medium '#{full_iso_file}'"
      Veewee::Shell.execute("#{command}")
     end
-
 
 
     def self.suppress_messages


### PR DESCRIPTION
The default VirtualBox setup uses 10.0.2.\* as the NAT network — which causes problems for folks who use that IP range on their internal network.  This patch makes the NAT network configurable through definition.rb, by using the --natnet1 option to VBoxManage.  See http://www.virtualbox.org/manual/ch09.html#changenat for more details
