### PR TITLE
Updated rubygems to fix an issue with json 1.6.1

### DIFF
--- a/templates/ubuntu-10.04.3-server-i386/postinstall.sh
+++ b/templates/ubuntu-10.04.3-server-i386/postinstall.sh
@@ -31,13 +31,13 @@ make install
 cd ..
 rm -rf ruby-1.8.7-p334*
 
-# Install RubyGems 1.7.2
-wget http://production.cf.rubygems.org/rubygems/rubygems-1.7.2.tgz
-tar xzf rubygems-1.7.2.tgz
-cd rubygems-1.7.2
+# Install RubyGems 1.8.15
+wget http://production.cf.rubygems.org/rubygems/rubygems-1.8.15.tgz
+tar xzf rubygems-1.8.15.tgz
+cd rubygems-1.8.15
 /opt/ruby/bin/ruby setup.rb
 cd ..
-rm -rf rubygems-1.7.2*
+rm -rf rubygems-1.8.15*
 
 # Installing chef & Puppet
 /opt/ruby/bin/gem install chef --no-ri --no-rdoc


### PR DESCRIPTION
The gem json 1.6.1 is installed by chef 0.10.8 (since the postinstall.sh script does not specify a chef version it installs the latest). This commit bumps the rubygems version to 1.8.15, the latest version right now.

The issue is the following:

```
Invalid gemspec in [/var/lib/gems/1.8/specifications/json-1.6.1.gemspec]: invalid date format in specification: "2011-09-18 00:00:00.000000000Z"
```
