### PR TITLE
fix for CentOS-6.0-x86_64-minimal to validate out of the box

### DIFF
--- a/templates/CentOS-6.0-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.0-x86_64-minimal/definition.rb
@@ -2,7 +2,7 @@ Veewee::Session.declare({
   :cpu_count => '1', :memory_size=> '384',
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
-  :iso_file => "CentOS-6.0-x86_64-minimal.iso", :iso_src => "http://be.mirror.eurid.eu/centos/6.0/isos/x86_64/CentOS-6.0-x86_64-minimal.iso", :iso_md5 => "b9fff4dad7aad0edaa564d7a251cb971", :iso_download_timeout => 1000,
+  :iso_file => "CentOS-6.0-x86_64-minimal.iso", :iso_src => "http://vault.centos.org/6.0/isos/x86_64/CentOS-6.0-x86_64-minimal.iso", :iso_md5 => "b9fff4dad7aad0edaa564d7a251cb971", :iso_download_timeout => 1000,
   :iso_download_instructions => "We can not download the ISO , you need to download it yourself and put it in the iso directory\n"+
   "- URL: http://isoredirect.centos.org/centos/6/isos/x86_64/ ",
   :boot_wait => "10", :boot_cmd_sequence => [

--- a/templates/CentOS-6.0-x86_64-minimal/postinstall.sh
+++ b/templates/CentOS-6.0-x86_64-minimal/postinstall.sh
@@ -2,7 +2,7 @@
 
 date > /etc/vagrant_box_build_time
 
-yum -y install gcc make gcc-c++ ruby kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl
+yum -y install gcc make gcc-c++ ruby zlib-devel openssl-devel readline-devel sqlite-devel perl
 
 cat > /etc/yum.repos.d/puppetlabs.repo << EOM
 [puppetlabs]
@@ -20,7 +20,7 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter ruby-devel rubygems
+yum -y install dkms puppet facter ruby-devel rubygems
 yum -y clean all
 rm /etc/yum.repos.d/{puppetlabs,epel}.repo
 
@@ -30,13 +30,21 @@ gem install --no-ri --no-rdoc chef
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh
 cd /home/vagrant/.ssh
-curl -L -o authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
+echo "Installing authorized keys for vagrant user"
+curl --silent -L -o authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 chown -R vagrant /home/vagrant/.ssh
 
 # Installing the virtualbox guest additions
 VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
 cd /tmp
-curl -L -o VBoxGuestAdditions_$VBOX_VERSION.iso http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso
+
+#force install the correct kernel headers for this version of centos
+echo "Retrieving and installing kernel-devel-2.6.32-71.el6.x86_64.rpm "
+curl --silent -L -o kernel-devel-2.6.32-71.el6.x86_64.rpm http://vault.centos.org/6.0/os/x86_64/Packages/kernel-devel-2.6.32-71.el6.x86_64.rpm
+sudo rpm -ivh --force kernel-devel-2.6.32-71.el6.x86_64.rpm
+
+echo "Retrieving and installing VBoxGuestAdditions"
+curl --silent -L -o VBoxGuestAdditions_$VBOX_VERSION.iso http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso
 mount -o loop VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
 sh /mnt/VBoxLinuxAdditions.run
 umount /mnt


### PR DESCRIPTION
Hej,

vagrant basebox validate did not work with CentOS-6.0-x86_64-minimal.  This fixes that.

using vault.centos.org to retrieve iso and kernel-devel rpm for the kernel verson in iso.

made sure that dkms is installed as well.

/brian
