### PR TITLE
Suppressing more dialogboxes

### DIFF
--- a/lib/veewee/session.rb
+++ b/lib/veewee/session.rb
@@ -677,7 +677,7 @@ module Veewee
       #Setting this annoying messages to register
       VirtualBox::ExtraData.global["GUI/RegistrationData"]="triesLeft=0"
       VirtualBox::ExtraData.global["GUI/UpdateDate"]="1 d, 2009-09-20"
-      VirtualBox::ExtraData.global["GUI/SuppressMessages"]="confirmInputCapture,remindAboutAutoCapture,remindAboutMouseIntegrationOff"
+      VirtualBox::ExtraData.global["GUI/SuppressMessages"]="confirmInputCapture,remindAboutAutoCapture,remindAboutMouseIntegrationOff,remindAboutMouseIntegrationOn,remindAboutWrongColorDepth"
       VirtualBox::ExtraData.global["GUI/UpdateCheckCount"]="60"
       update_date=Time.now+86400
       VirtualBox::ExtraData.global["GUI/UpdateDate"]="1 d, #{update_date.year}-#{update_date.month}-#{update_date.day}, stable"


### PR DESCRIPTION
Not suppressing these cause invalid states when shutting down etc.

Just revisited veewee 0.2.x and found that these are needed.
