### PR TITLE
Allow users to set VEEWEE_DIR env var to override

### DIFF
--- a/lib/veewee/command.rb
+++ b/lib/veewee/command.rb
@@ -7,7 +7,7 @@ Dir.glob(File.join(lib_dir, '**','*.rb')).each {|f| require f  }
 #Setup some base variables to use
 template_dir=File.expand_path(File.join(lib_dir,"..", "templates"))
 
-veewee_dir="."
+veewee_dir=ENV['VEEWEE_DIR'] || "."
 definition_dir= File.expand_path(File.join(veewee_dir, "definitions"))
 tmp_dir=File.expand_path(File.join(veewee_dir, "tmp"))
 iso_dir=File.expand_path(File.join(veewee_dir, "iso"))


### PR DESCRIPTION
Currently Veewee expects a directory structure to exist under the present working directory (PWD), but this is not how everyone would like to structure their project in their project root directory.

This is the simplest fix for those of us that wish to have our base box definitions under a subdirectory by setting `VEEWEE_DIR` environment variable to taste. I verified locally (by `rake install`, setting `VEEWEE_DIR` to a subdirectory with definitions dir and was able to run `vagrant basebox list` and related commands as expected).

I am open to adding unit tests for this, but I didn't find a test directory already existing. Let me know where to add my tests and I will do so then I can rebase/squash/force-push back for your to review and hopefully merge in.
