### PR TITLE
Use sudoers.d instead of sudoers

### DIFF
--- a/templates/CentOS-6.0-i386-netboot/ks.cfg
+++ b/templates/CentOS-6.0-i386-netboot/ks.cfg
@@ -49,4 +49,5 @@ facter
 /usr/sbin/groupadd vagrant
 /usr/sbin/useradd vagrant -g vagrant -G wheel
 echo "vagrant"|passwd --stdin vagrant
-echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant

--- a/templates/CentOS-6.0-i386/ks.cfg
+++ b/templates/CentOS-6.0-i386/ks.cfg
@@ -44,4 +44,5 @@ sqlite-devel
 /usr/sbin/groupadd vagrant
 /usr/sbin/useradd vagrant -g vagrant -G wheel
 echo "vagrant"|passwd --stdin vagrant
-echo "vagrant		ALL=(ALL)		NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant

--- a/templates/CentOS-6.0-x86_64-minimal/ks.cfg
+++ b/templates/CentOS-6.0-x86_64-minimal/ks.cfg
@@ -34,4 +34,5 @@ bzip2
 /usr/sbin/groupadd vagrant
 /usr/sbin/useradd vagrant -g vagrant -G wheel
 echo "vagrant"|passwd --stdin vagrant
-echo "vagrant		ALL=(ALL)		NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant

--- a/templates/CentOS-6.0-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-6.0-x86_64-netboot/ks.cfg
@@ -49,4 +49,6 @@ facter
 /usr/sbin/groupadd vagrant
 /usr/sbin/useradd vagrant -g vagrant -G wheel
 echo "vagrant"|passwd --stdin vagrant
-echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+

--- a/templates/CentOS-6.0-x86_64/ks.cfg
+++ b/templates/CentOS-6.0-x86_64/ks.cfg
@@ -44,4 +44,5 @@ sqlite-devel
 /usr/sbin/groupadd vagrant
 /usr/sbin/useradd vagrant -g vagrant -G wheel
 echo "vagrant"|passwd --stdin vagrant
-echo "vagrant		ALL=(ALL)		NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant

--- a/templates/CentOS-6.1-x86_64-minimal/ks.cfg
+++ b/templates/CentOS-6.1-x86_64-minimal/ks.cfg
@@ -42,4 +42,6 @@ wget
 /usr/sbin/groupadd veewee
 /usr/sbin/useradd veewee -g veewee -G wheel
 echo "veewee"|passwd --stdin veewee
-echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+

--- a/templates/CentOS-6.1-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-6.1-x86_64-netboot/ks.cfg
@@ -41,4 +41,6 @@ sqlite-devel
 /usr/sbin/groupadd veewee
 /usr/sbin/useradd veewee -g veewee -G wheel
 echo "veewee"|passwd --stdin veewee
-echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+

--- a/templates/CentOS-6.2-x86_64-minimal/ks.cfg
+++ b/templates/CentOS-6.2-x86_64-minimal/ks.cfg
@@ -34,5 +34,6 @@ bzip2
 /usr/sbin/groupadd veewee
 /usr/sbin/useradd veewee -g veewee -G wheel
 echo "veewee"|passwd --stdin veewee
-echo "veewee		ALL=(ALL)		NOPASSWD: ALL" >> /etc/sudoers
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
 

--- a/templates/CentOS-6.2-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-6.2-x86_64-netboot/ks.cfg
@@ -41,4 +41,6 @@ sqlite-devel
 /usr/sbin/groupadd veewee
 /usr/sbin/useradd veewee -g veewee -G wheel
 echo "veewee"|passwd --stdin veewee
-echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+


### PR DESCRIPTION
Adding a new file to /etc/sudoers.d is a preferred method of changing sudoers configuration in RedHat and CentOS.

Changing kickstart configuration to create /etc/sudoers.d/veewee | vagrant file instead of appending veewee user to /etc/sudoers.
