### PR TITLE
Remove package locks for opensuse basebox templates.

### DIFF
--- a/templates/openSUSE-11.4-DVD-i586/postinstall.sh
+++ b/templates/openSUSE-11.4-DVD-i586/postinstall.sh
@@ -27,6 +27,11 @@ echo -e "\ninstall chef and puppet ..."
 gem install chef --no-ri --no-rdoc
 gem install puppet --no-ri --no-rdoc
 
+# remove zypper locks, preventing installation of additional packages,
+# present because of the autoinst <software><remove-packages>
+echo -e "\nremove zypper package locks ..."
+rm -f /etc/zypp/locks
+
 # install the virtualbox guest additions
 echo -e "\ninstall the virtualbox guest additions ..."
 zypper --non-interactive remove `rpm -qa virtualbox-guest-*`

--- a/templates/openSUSE-11.4-DVD-x86_64/postinstall.sh
+++ b/templates/openSUSE-11.4-DVD-x86_64/postinstall.sh
@@ -27,6 +27,11 @@ echo -e "\ninstall chef and puppet ..."
 gem install chef --no-ri --no-rdoc
 gem install puppet --no-ri --no-rdoc
 
+# remove zypper locks, preventing installation of additional packages,
+# present because of the autoinst <software><remove-packages>
+echo -e "\nremove zypper package locks ..."
+rm -f /etc/zypp/locks
+
 # install the virtualbox guest additions
 echo -e "\ninstall the virtualbox guest additions ..."
 zypper --non-interactive remove `rpm -qa virtualbox-guest-*`

--- a/templates/openSUSE-11.4-NET-i586/postinstall.sh
+++ b/templates/openSUSE-11.4-NET-i586/postinstall.sh
@@ -27,6 +27,11 @@ echo -e "\ninstall chef and puppet ..."
 gem install chef --no-ri --no-rdoc
 gem install puppet --no-ri --no-rdoc
 
+# remove zypper locks, preventing installation of additional packages,
+# present because of the autoinst <software><remove-packages>
+echo -e "\nremove zypper package locks ..."
+rm -f /etc/zypp/locks
+
 # install the virtualbox guest additions
 echo -e "\ninstall the virtualbox guest additions ..."
 zypper --non-interactive remove `rpm -qa virtualbox-guest-*`

--- a/templates/openSUSE-11.4-NET-x86_64/postinstall.sh
+++ b/templates/openSUSE-11.4-NET-x86_64/postinstall.sh
@@ -27,6 +27,11 @@ echo -e "\ninstall chef and puppet ..."
 gem install chef --no-ri --no-rdoc
 gem install puppet --no-ri --no-rdoc
 
+# remove zypper locks, preventing installation of additional packages,
+# present because of the autoinst <software><remove-packages>
+echo -e "\nremove zypper package locks ..."
+rm -f /etc/zypp/locks
+
 # install the virtualbox guest additions
 echo -e "\ninstall the virtualbox guest additions ..."
 zypper --non-interactive remove `rpm -qa virtualbox-guest-*`

--- a/templates/openSUSE-12.1-DVD+NET-i586/postinstall.sh
+++ b/templates/openSUSE-12.1-DVD+NET-i586/postinstall.sh
@@ -27,6 +27,11 @@ echo -e "\ninstall chef and puppet ..."
 gem install chef --no-ri --no-rdoc
 gem install puppet --no-ri --no-rdoc
 
+# remove zypper locks, preventing installation of additional packages,
+# present because of the autoinst <software><remove-packages>
+echo -e "\nremove zypper package locks ..."
+rm -f /etc/zypp/locks
+
 # install the virtualbox guest additions
 echo -e "\ninstall the virtualbox guest additions ..."
 zypper --non-interactive remove `rpm -qa virtualbox-guest-*`

--- a/templates/openSUSE-12.1-DVD+NET-x86_64/postinstall.sh
+++ b/templates/openSUSE-12.1-DVD+NET-x86_64/postinstall.sh
@@ -27,6 +27,11 @@ echo -e "\ninstall chef and puppet ..."
 gem install chef --no-ri --no-rdoc
 gem install puppet --no-ri --no-rdoc
 
+# remove zypper locks, preventing installation of additional packages,
+# present because of the autoinst <software><remove-packages>
+echo -e "\nremove zypper package locks ..."
+rm -f /etc/zypp/locks
+
 # install the virtualbox guest additions
 echo -e "\ninstall the virtualbox guest additions ..."
 zypper --non-interactive remove `rpm -qa virtualbox-guest-*`


### PR DESCRIPTION
Fix for https://github.com/jedi4ever/veewee/issues/236

I now remove the zypper package locks in the postinstall.sh scripts for the opensuse basebox templates.
