### PR TITLE
Create an empty folder for staging floppy files

### DIFF
--- a/lib/veewee/provider/core/box/floppy.rb
+++ b/lib/veewee/provider/core/box/floppy.rb
@@ -9,7 +9,8 @@ module Veewee
           # Check for floppy
           unless definition.floppy_files.nil?
             require 'tmpdir'
-            temp_dir=Dir.mktmpdir
+            temp_dir=File.join(Dir::tmpdir, "veewee_#{Time.now.to_i}_#{rand(1000)}")
+            Dir.mkdir(temp_dir)
             definition.floppy_files.each do |filename|
               full_filename=full_filename=File.join(definition.path,filename)
               FileUtils.cp("#{full_filename}","#{temp_dir}")


### PR DESCRIPTION
When the virtual floppy disk file is created from `/tmp`, a whole lot of other junk gets included. So, stage the files to a new empty directory under `/tmp`. 
