### PR TITLE
Amend vagrant @ sudoers to leverage sudoers.d/ include @ CentOS >= 6.1.  Ducks sudo cookbook/module/bundle stomping.

### DIFF
--- a/templates/CentOS-6.1-x86_64-minimal/vagrant.sh
+++ b/templates/CentOS-6.1-x86_64-minimal/vagrant.sh
@@ -5,7 +5,8 @@ date > /etc/vagrant_box_build_time
 /usr/sbin/groupadd vagrant
 /usr/sbin/useradd vagrant -g vagrant -G wheel
 echo "vagrant"|passwd --stdin vagrant
-echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
 
 # Installing vagrant keys
 mkdir -p /home/vagrant/.ssh

--- a/templates/CentOS-6.1-x86_64-netboot/vagrant.sh
+++ b/templates/CentOS-6.1-x86_64-netboot/vagrant.sh
@@ -5,7 +5,8 @@ date > /etc/vagrant_box_build_time
 /usr/sbin/groupadd vagrant
 /usr/sbin/useradd vagrant -g vagrant -G wheel
 echo "vagrant"|passwd --stdin vagrant
-echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
 
 # Installing vagrant keys
 mkdir -p /home/vagrant/.ssh

--- a/templates/CentOS-6.2-x86_64-minimal/vagrant.sh
+++ b/templates/CentOS-6.2-x86_64-minimal/vagrant.sh
@@ -5,7 +5,8 @@ date > /etc/vagrant_box_build_time
 /usr/sbin/groupadd vagrant
 /usr/sbin/useradd vagrant -g vagrant -G wheel
 echo "vagrant"|passwd --stdin vagrant
-echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
 
 # Installing vagrant keys
 mkdir -p /home/vagrant/.ssh

--- a/templates/CentOS-6.2-x86_64-netboot/vagrant.sh
+++ b/templates/CentOS-6.2-x86_64-netboot/vagrant.sh
@@ -5,7 +5,8 @@ date > /etc/vagrant_box_build_time
 /usr/sbin/groupadd vagrant
 /usr/sbin/useradd vagrant -g vagrant -G wheel
 echo "vagrant"|passwd --stdin vagrant
-echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
 
 # Installing vagrant keys
 mkdir -p /home/vagrant/.ssh


### PR DESCRIPTION
...book/module/bundle stomping.
