### PR TITLE
Fix download URL for VBoxGuestAdditions ISO on Debian hosts.

### DIFF
--- a/lib/veewee/provider/virtualbox/box/helper/version.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/version.rb
@@ -3,10 +3,12 @@ module Veewee
     module Virtualbox
       module BoxCommand
 
+        # Return the major/minor/incremental version of VirtualBox.
+        # For example: 4.1.8_Debianr75467 -> 4.1.8
         def vbox_version
           command="#{@vboxcmd} --version"
           shell_results=shell_exec("#{command}",{:mute => true})
-          version=shell_results.stdout.strip.split('r')[0]
+          version=shell_results.stdout.strip.split(/[^0-9\.]/)[0]
           return version
         end
 


### PR DESCRIPTION
`VBoxManage -v` on Debian reports a version number of the form:
4.1.8_Debianr75467

The URL from which to download the VBoxGuestAdditions ISO is derived
from the major/minor/incrmemental version numbers, but this was not
being correctly parsed from the version reported by VBoxManage.
