### PR TITLE
Fix ostype for FreeBSD_64 on VirtualBox. 

### DIFF
--- a/lib/veewee/config/ostypes.yml
+++ b/lib/veewee/config/ostypes.yml
@@ -112,7 +112,7 @@ FreeBSD:
 FreeBSD_64:
   :fusion: FreeBSD_64
   :kvm:
-  :vbox: FreeBSD-64
+  :vbox: FreeBSD_64
   :parallels: freebsd
 Oracle:
   :fusion: oraclelinux


### PR DESCRIPTION
VBox 4.1.10 only recognizes 'FreeBSD_64' as valid, not 'FreeBSD-64'.
