### PR TITLE
Setting the correct OS type ID for Fedora 16 64bit definition.

### DIFF
--- a/templates/Fedora-16-x86_64/definition.rb
+++ b/templates/Fedora-16-x86_64/definition.rb
@@ -2,7 +2,7 @@ Veewee::Session.declare({
   # Minimum RAM requirement for installation is 768MB.
   :cpu_count => '1', :memory_size=> '768',
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :hwvirtext => 'on',
-  :os_type_id => 'Fedora',
+  :os_type_id => 'Fedora_64',
   :iso_file => "Fedora-16-x86_64-DVD.iso",
   :iso_src => "http://download.fedoraproject.org/pub/fedora/linux/releases/16/Fedora/x86_64/iso/Fedora-16-x86_64-DVD.iso",
   :iso_md5 => "bb38ea1fe4b2fc69e7a6e15cf1c69c91",


### PR DESCRIPTION
I couldn't get the Fedora 16 64bit definition to build with veewee, and poked around a little and found this.  It works with this fix, and the Fedora 14,15 definitions use this for the os type id for the 64bit definitions, so seems legit.  Loving veewee ;)  Thanks!
