### PR TITLE
Open file in binary mode for checksum computation.

### DIFF
--- a/lib/veewee/provider/core/helper/iso.rb
+++ b/lib/veewee/provider/core/helper/iso.rb
@@ -51,7 +51,7 @@ module Veewee
           def hashsum(filename)
             checksum=Digest::MD5.new
             buflen=1024
-            open(filename, "r") do |io|
+            open(filename, "rb") do |io|
               counter = 0
               while (!io.eof)
                 readBuf = io.readpartial(buflen)


### PR DESCRIPTION
File being verified should be read in binary mode for cross-platform compatibility (relates to #6).
