### PR TITLE
Use double quotes in shell command for compatibility with Windows

### DIFF
--- a/lib/veewee/provider/virtualbox/box/helper/natinterface.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/natinterface.rb
@@ -4,7 +4,7 @@ module Veewee
       module BoxCommand
 
         def natinterface
-          command="#{@vboxcmd} showvminfo --details --machinereadable '#{self.name}'"
+          command="#{@vboxcmd} showvminfo --details --machinereadable \"#{self.name}\""
           shell_results=shell_exec("#{command}")
 
           nic_id=shell_results.stdout.split(/\n/).grep(/^nic/).grep(/nat/)[0].split('=')[0][-1,1]


### PR DESCRIPTION
Ref #6.
