### PR TITLE
Using the latest version, the option "basebox" does not exist. 

### DIFF
--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -6,7 +6,7 @@ this is essentially making a copy based on the  templates provided above.
     The basebox 'myubuntubox' has been succesfully created from the template ''ubuntu-10.10-server-i386'
     You can now edit the definition files stored in definitions/myubuntubox
     or build the box with:
-    veewee vbox basebox build 'myubuntubox'
+    veewee vbox build 'myubuntubox'
 
 -> This copies over the templates/ubuntu-10.10-server-i386 to definition/myubuntubox
 
@@ -47,7 +47,7 @@ If you need to change values in the templates, be sure to run the rake undefine,
 ## Getting the cdrom file in place
 Put your isofile inside the 'currentdir'/iso directory or if you don't run
 
-    $ veewee vbox basebox build 'myubuntubox'
+    $ veewee vbox build 'myubuntubox'
 
 - the build assumes your iso files are in 'currentdir'/iso
 - if it can not find it will suggest to download the iso for you
@@ -55,7 +55,7 @@ Put your isofile inside the 'currentdir'/iso directory or if you don't run
 
 ## Build the new box:
 
-    $ veewee vbox basebox build 'myubuntubox'
+    $ veewee vbox build 'myubuntubox'
 
 - This will create a machine + disk according to the definition.rb
 - Note: :os_type_id = The internal Name Virtualbox uses for that Distribution
@@ -108,7 +108,7 @@ If you don't use rvm, be sure to execute vagrant through bundle exec
 
 Start of an existing one
 
-    $ veewee vbox basebox define 'mynewos' 'ubuntu...'
+    $ veewee vbox define 'mynewos' 'ubuntu...'
 
 - Do changes in the currentdir/definitions/mynewos
 - When it builds ok, move the definition/mynewos to a sensible directory under templates


### PR DESCRIPTION
To create a vbox, the execution is "$ veewee vbox define 'myubuntubox' 'ubuntu-10.10-server-i386'"
