### PR TITLE
Updated rubygem version to 1.8.22 - issue #284

### DIFF
--- a/2012-04-19-07-28-06.050-VirtualBoxVM-67911.log
+++ b/2012-04-19-07-28-06.050-VirtualBoxVM-67911.log
@@ -1,3 +1,0 @@
-Log created: 2012-04-19T07:28:06.507176000Z
-Executable: /Applications/VirtualBox.app/Contents/MacOS/../Resources/VirtualBoxVM.app/Contents/MacOS/VirtualBoxVM
-VERR_FILE_NOT_FOUND (-102) - File not found.


### PR DESCRIPTION
The build of the box would fail after the installation of Rubygems 1.6.2.

With 1.8.22 Box creation will finish.
