### PR TITLE
* Added --use-emulation option to 'veewee kvm build' command

### DIFF
--- a/lib/veewee/command/kvm.rb
+++ b/lib/veewee/command/kvm.rb
@@ -10,6 +10,7 @@ module Veewee
       method_option :auto,:type => :boolean , :default => false, :aliases => "-a", :desc => "auto answers"
       method_option :postinstall_include, :type => :array, :default => [], :aliases => "-i", :desc => "ruby regexp of postinstall filenames to additionally include"
       method_option :postinstall_exclude, :type => :array, :default => [], :aliases => "-e", :desc => "ruby regexp of postinstall filenames to exclude"
+      method_option :use_emulation, :type => :boolean , :default => false, :desc => "Use QEMU emulation"
       def build(box_name)
         venv=Veewee::Environment.new(options)
         venv.ui=env.ui

--- a/lib/veewee/provider/kvm/box/create.rb
+++ b/lib/veewee/provider/kvm/box/create.rb
@@ -22,6 +22,7 @@ module Veewee
             :cpus => definition.cpu_count.to_i,
             :volume_capacity => "#{definition.disk_size}M",
             :network_interface_type => "nat",
+            :domain_type => options['use_emulation'] ? 'qemu': 'kvm',
             :iso_file => definition.iso_file,
             :arch => definition.os_type_id.end_with?("_64") ? "x86_64" : "i686",
             :iso_dir => env.config.veewee.iso_dir


### PR DESCRIPTION
Hey Patrick, how do you feel about adding something like this? 

We're using veewee 0.3 alpha to build appliances remotely on a VM and we need something like this, otherwise kvm build command fails with:

```
failed to initialize KVM: No such file or directory
No accelerator found!
```

Thanks.
