### PR TITLE
updated rubygems in ubuntu11.04 templates to 1.8.x

### DIFF
--- a/templates/ubuntu-11.04-server-amd64/ruby.sh
+++ b/templates/ubuntu-11.04-server-amd64/ruby.sh
@@ -17,12 +17,12 @@ cd ..
 rm -rf ruby-1.8.7-p334*
 
 # Install RubyGems 1.7.2
-wget http://production.cf.rubygems.org/rubygems/rubygems-1.7.2.tgz
-tar xzf rubygems-1.7.2.tgz
-cd rubygems-1.7.2
+wget http://production.cf.rubygems.org/rubygems/rubygems-1.8.11.tgz
+tar xzf rubygems-1.8.11.tgz
+cd rubygems-1.8.11
 /opt/ruby/bin/ruby setup.rb
 cd ..
-rm -rf rubygems-1.7.2*
+rm -rf rubygems-1.8.11
 
 # Add /opt/ruby/bin to the global path as the last resort so
 # Ruby, RubyGems, and Chef/Puppet are visible

--- a/templates/ubuntu-11.04-server-i386/postinstall.sh
+++ b/templates/ubuntu-11.04-server-i386/postinstall.sh
@@ -43,12 +43,12 @@ cd ..
 rm -rf ruby-1.8.7-p334*
 
 # Install RubyGems 1.7.2
-wget http://production.cf.rubygems.org/rubygems/rubygems-1.7.2.tgz
-tar xzf rubygems-1.7.2.tgz
-cd rubygems-1.7.2
+wget http://production.cf.rubygems.org/rubygems/rubygems-1.8.11.tgz
+tar xzf rubygems-1.8.11.tgz
+cd rubygems-1.8.11
 /opt/ruby/bin/ruby setup.rb
 cd ..
-rm -rf rubygems-1.7.2*
+rm -rf rubygems-1.8.11
 
 # Installing chef & Puppet
 /opt/ruby/bin/gem install chef --no-ri --no-rdoc


### PR DESCRIPTION
Previously these builds were using rubygems 1.7.2 which causes
a lot of issue, especially this one that can cause major headaches
when doing anything ruby related inside the vm:

```
Invalid gemspec in [/usr/local/lib/ruby/gems/1.8/specifications/merb_datamapper-1.1.3.gemspec]: invalid date format in specification: "2011-05-03 00:00:00.000000000Z"
```
