### PR TITLE
Fix ISO filenames.

### DIFF
--- a/templates/Debian-6.0.5-amd64-netboot/definition.rb
+++ b/templates/Debian-6.0.5-amd64-netboot/definition.rb
@@ -3,7 +3,7 @@ Veewee::Definition.declare({
   :memory_size=> '256',
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
-  :iso_file => "debian-6.0.4-amd64-netinst.iso",
+  :iso_file => "debian-6.0.5-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/debian-cd/6.0.5/amd64/iso-cd/debian-6.0.5-amd64-netinst.iso",
   :iso_md5 => "a213b1d6da1996c677706d843b6ee0f2",
   :iso_download_timeout => "1000",

--- a/templates/Debian-6.0.5-i386-netboot/definition.rb
+++ b/templates/Debian-6.0.5-i386-netboot/definition.rb
@@ -5,7 +5,7 @@ Veewee::Definition.declare({
   :memory_size=> '256',
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian',
-  :iso_file => "debian-6.04-i386-netinst.iso",
+  :iso_file => "debian-6.0.5-i386-netinst.iso",
   :iso_src => "http://cdimage.debian.org/debian-cd/6.0.5/i386/iso-cd/debian-6.0.5-i386-netinst.iso",
   :iso_md5 => "bdf926d604258ce17dfba0b5ef067f17",
   :iso_download_timeout => "1000",


### PR DESCRIPTION
Update the Debian-6.0.5-{amd64,i386}-netboot templates with the correct
output filenames for each ISO.
