### PR TITLE
Add support for git:// URLs for templates.

### DIFF
--- a/lib/veewee/definitions.rb
+++ b/lib/veewee/definitions.rb
@@ -1,3 +1,4 @@
+require 'grit'
 require 'veewee/definition'
 require 'veewee/templates'
 require 'veewee/template'
@@ -39,7 +40,7 @@ module Veewee
       end
 
       if definitions.length==0
-        env.logger.debug("[Definition] no definitions found") 
+        env.logger.debug("[Definition] no definitions found")
       end
 
       definitions.each(&block)
@@ -61,9 +62,14 @@ module Veewee
 
       env.logger.debug("Forceflag : #{options['force']}")
 
+      git_template=false
+      # Check if the template is a git repo
+      if template_name.start_with?("git://")
+        git_template=true
+      end
       # Check if template exists
       template=env.templates[template_name]
-      if template.nil?
+      if template.nil? and ! git_template
         env.logger.fatal("Template '#{template_name}' does not exist")
         raise Veewee::TemplateError, "Template '#{template_name}' does not exist"
       else
@@ -89,13 +95,25 @@ module Veewee
       env.logger.debug("Definition Directory '#{File.join(env.definition_dir,definition_name)}' succesfuly created")
 
       # Start copying/cloning the directory of the template to the definition directory
-      begin
-        env.logger.debug("Starting copy '#{template.path}' to '#{dst_dir}'")
-        FileUtils.cp_r(template.path+"/.",dst_dir)
-        env.logger.debug("Copy '#{template.path}' to '#{dst_dir}' succesfull")
-      rescue Exception => ex
-        env.logger.fatal("Copy '#{template.path}' to #{dst_dir}' failed: #{ex}")
-        raise Veewee::Error , "Copy '#{template.path}' to #{dst_dir}' failed: #{ex}"
+      if (git_template)
+        begin
+          env.logger.debug("Starting git clone #{template_name} #{dst_dir}")
+          g = Grit::Git.new(dst_dir)
+          g.clone({ :timeout => false }, template_name, dst_dir)
+        rescue Exception => ex
+          err = "git clone #{template_name} #{dst_dir} failed: #{ex}"
+          env.logger.fatal(err)
+          raise Veewee::Error, err
+        end
+      else
+        begin
+          env.logger.debug("Starting copy '#{template.path}' to '#{dst_dir}'")
+          FileUtils.cp_r(template.path+"/.",dst_dir)
+          env.logger.debug("Copy '#{template.path}' to '#{dst_dir}' succesfull")
+        rescue Exception => ex
+          env.logger.fatal("Copy '#{template.path}' to #{dst_dir}' failed: #{ex}")
+          raise Veewee::Error , "Copy '#{template.path}' to #{dst_dir}' failed: #{ex}"
+        end
       end
 
       definition=env.definitions[definition_name]

--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ruby-vnc", "~> 1.0.0"
   s.add_dependency "fog", "~> 1.1.2"
   s.add_dependency "childprocess"
+  s.add_dependency "grit"
 
   # Modified dependency version, as libxml-ruby dependency has been removed in version 2.1.1
   # See : https://github.com/ckruse/CFPropertyList/issues/14


### PR DESCRIPTION
Here's a stab at adding support for git base box definitions.

veewee vbox define mytestbox git://github.com/ferlatte/vagrant-tetherpad-heroku.git

works for me. ;)

Let me know if you'd like this cleaned up or done in a different way.
