### PR TITLE
More specific error message when building basebox

### DIFF
--- a/lib/veewee/provider/core/helper/iso.rb
+++ b/lib/veewee/provider/core/helper/iso.rb
@@ -91,7 +91,7 @@ module Veewee
               rel_path=path1.relative_path_from(path2).to_s
 
               ui.info ""
-              ui.info "We did not find an isofile of name #{filename} in #{full_path}/iso. \n\nThe definition provided the following download information:"
+              ui.info "We did not find an isofile here : #{full_path}. \n\nThe definition provided the following download information:"
               unless "#{self.iso_src}"==""
                 ui.info "- Download url: #{self.iso_src}"
               end


### PR DESCRIPTION
 "#{current_dir}" is more helpful error than "<current_dir>" .... changing the source in my local gem then rebuilding the gem from source allowed me to determine where to put my iso and to make sure the names were right.  
