### PR TITLE
Bump the fog dependency to ~> 1.4.

### DIFF
--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "cucumber", ">=1.0.0"
   s.add_dependency "ansi", "~> 1.3.0"
   s.add_dependency "ruby-vnc", "~> 1.0.0"
-  s.add_dependency "fog", "~> 1.1.2"
+  s.add_dependency "fog", "~> 1.4"
   s.add_dependency "childprocess"
 
   # Modified dependency version, as libxml-ruby dependency has been removed in version 2.1.1


### PR DESCRIPTION
The gem version dependency on fog is over 6 months old. This makes it difficult to use veewee as a gem dependency in a project that also uses fog. Updating the fog dependency and cutting a new prerelease gem would help us out a lot. thanks.
