### PR TITLE
added a 'yum install kernel' to the kickstart file to make it so that we...

### DIFF
--- a/templates/CentOS-6.2-x86_64-minimal/ks.cfg
+++ b/templates/CentOS-6.2-x86_64-minimal/ks.cfg
@@ -36,4 +36,5 @@ bzip2
 echo "veewee"|passwd --stdin veewee
 echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
 chmod 0440 /etc/sudoers.d/veewee
+/usr/bin/yum -y install kernel
 


### PR DESCRIPTION
... can sync the kernel-devel version in the updates repo

There is probably a better way to do this, but this got me working.  Otherwise the virtual box additions wouldn't compile because the package requested in base.rb ( in the line "yum install -y ... kernel-devel-`uname -r` ...") didn't match the package version in the updates repo.  I didn't check the other CentOS 6.2 templates, but they may have the same problem.
