### PR TITLE
Patch to treat .erb files as ERB templates

### DIFF
--- a/lib/veewee/environment.rb
+++ b/lib/veewee/environment.rb
@@ -69,14 +69,6 @@ module Veewee
       }
 
       options = defaults.merge(options)
-      veeweefile_config = defaults.keys.inject({}) do |memo,obj|
-        if config.env.methods.include?(obj) && !config.env.send(obj).nil?
-          memo.merge({ obj => config.env.send(obj) })
-        else
-          memo
-        end
-      end
-      options = options.merge(veeweefile_config)
 
       # We need to set this variable before the first call to the logger object
       if options.has_key?("debug")


### PR DESCRIPTION
Hi Patrick,

Some of the guys here at LivingSocial thought it would be super useful to be able to render kickstart/postinstall files from ERB templates. So here's a really simple patch that treats anything with a .erb extension as an ERB template.

Thanks for Veewee!
