### PR TITLE
Chef run outputs `stdin: not a tty` when first starts on lucid64

### DIFF
--- a/templates/ubuntu-10.04.4-server-amd64/postinstall.sh
+++ b/templates/ubuntu-10.04.4-server-amd64/postinstall.sh
@@ -58,6 +58,15 @@ rm -rf rubygems-1.8.17*
 # Ruby, RubyGems, and Chef/Puppet are visible
 echo 'PATH=$PATH:/opt/ruby/bin/'> /etc/profile.d/vagrantruby.sh
 
+# Need conditionals around `mesg n` so that Chef doesn't throw
+# `stdin: not a tty`
+sed -i '$d' /root/.profile
+cat << 'EOH' >> /root/.profile
+if `tty -s`; then
+  mesg n
+fi
+EOH
+
 # Installing vagrant keys
 mkdir /home/vagrant/.ssh
 chmod 700 /home/vagrant/.ssh


### PR DESCRIPTION
Solved by @mparker17 in myplanetdigital/ariadne#14

Relevant:
http://tech.karbassi.com/2011/11/09/stdin-is-not-a-tty/

Going to submit a PR for lucid64, but not currently testing other lucid platforms which probably experience something similar.

Cheers!
