### PR TITLE
Merge options from Veeweefile

### DIFF
--- a/lib/veewee/environment.rb
+++ b/lib/veewee/environment.rb
@@ -69,6 +69,14 @@ module Veewee
       }
 
       options = defaults.merge(options)
+      veeweefile_config = defaults.keys.inject({}) do |memo,obj|
+        if config.env.methods.include?(obj) && !config.env.send(obj).nil?
+          memo.merge({ obj => config.env.send(obj) })
+        else
+          memo
+        end
+      end
+      options = options.merge(veeweefile_config)
 
       # We need to set this variable before the first call to the logger object
       if options.has_key?("debug")

--- a/lib/veewee/provider/core/helper/web.rb
+++ b/lib/veewee/provider/core/helper/web.rb
@@ -21,15 +21,10 @@ module Veewee
             def do_GET(request,response)
               response['Content-Type']='text/plain'
               response.status = 200
-              content = File.open(@localfile, "r").read
-              response.body = case File.extname(@localfile)
-              when ".erb"
-                ui.info "Rendering and serving file #{@localfile}"
-                ERB.new(content).result(binding)
-              else
-                ui.info "Serving file #{@localfile}"
-                content
-              end
+              ui.info "Serving file #{@localfile}"
+              displayfile=File.open(@localfile,'r')
+              content=displayfile.read()
+              response.body=content
               #If we shut too fast it might not get the complete file
               sleep 2
               @server.shutdown


### PR DESCRIPTION
We discovered evidence that it should be possible to configure Veewee via a "Veeweefile," but since we couldn't find any documentation on this particular feature (nor could we get it to work "out of the box"), we basically had to reverse-engineer it.

The Veeweefile appears to expect a format like this:

```
Veewee::Config.run do |config|
  config.veewee.<option> = <value>
end
```

Although the file above will get parsed without errors, we could not get Veewee to honor any of the options set within the Veeweefile. `Veewee::Environment#initialize` does not seem to read the Veeweefile on its own. Interestingly the call to env.load! in https://github.com/jedi4ever/veewee/blob/master/bin/veewee#L15 gives us what we want, but https://github.com/jedi4ever/veewee/blob/master/lib/veewee/command/virtualbox.rb#L14-18 (for example) is missing the crucial call to `venv.load!`, which means you will just end up with the default options every time. 

Rather than adding `venv.load!` all over the place, I decided to patch `Veewee::Environment#initialize` so that the Veeweefile options get merged in right from the beginning. I hope this was the right thing to do...
