### PR TITLE
Treat .erb files as ERB templates before serving

### DIFF
--- a/lib/veewee/provider/core/helper/web.rb
+++ b/lib/veewee/provider/core/helper/web.rb
@@ -21,10 +21,15 @@ module Veewee
             def do_GET(request,response)
               response['Content-Type']='text/plain'
               response.status = 200
-              ui.info "Serving file #{@localfile}"
-              displayfile=File.open(@localfile,'r')
-              content=displayfile.read()
-              response.body=content
+              content = File.open(@localfile, "r").read
+              response.body = case File.extname(@localfile)
+              when ".erb"
+                ui.info "Rendering and serving file #{@localfile}"
+                ERB.new(content).result(binding)
+              else
+                ui.info "Serving file #{@localfile}"
+                content
+              end
               #If we shut too fast it might not get the complete file
               sleep 2
               @server.shutdown


### PR DESCRIPTION
Hi Patrick,

Some of the guys here at LivingSocial thought it would be super useful to be able to render kickstart/postinstall files from ERB templates. So here's a really simple patch that treats anything with a .erb extension as an ERB template.

Thanks for Veewee!
