### PR TITLE
"windows-7-enterprise-amd64" doesn't seem to complete

### DIFF
--- a/templates/windows-7-enterprise-amd64/Autounattend.xml
+++ b/templates/windows-7-enterprise-amd64/Autounattend.xml
@@ -98,22 +98,22 @@
                 <Enabled>true</Enabled>
             </AutoLogon>
             <FirstLogonCommands>
-                <!-- <SynchronousCommand wcm:action="add"> -->
-                <!--     <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine> -->
-                <!--     <Description>Install Cygwin SSH</Description> -->
-                <!--     <Order>1</Order> -->
-                <!--     <RequiresUserInput>true</RequiresUserInput> -->
-                <!-- </SynchronousCommand> -->
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
+                    <Description>Install Cygwin SSH</Description>
+                    <Order>1</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:install-vbox-guest.bat</CommandLine>
                     <Description>Install Win RM</Description>
-                    <Order>1</Order>
+                    <Order>2</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:install-winrm.bat</CommandLine>
                     <Description>Install Win RM</Description>
-                    <Order>2</Order>
+                    <Order>3</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>


### PR DESCRIPTION
Not sure whether it was intentional, but this template seems to build the system, but the shell hangs waiting to connect via ssh, and the VM seems to finish in the GUI with a running win7 instance.

Seems the cywin install portion of the `autounattend.xml` file was commented out. Not sure why, but putting it back seems to fix it. Perhaps someone else could comment on why it was commented out in the first place? //cc @hippiehacker

I'll submit a PR
