### PR TITLE
floppy file name being overwritten by one from an internal loop

### DIFF
--- a/lib/veewee/provider/core/box/floppy.rb
+++ b/lib/veewee/provider/core/box/floppy.rb
@@ -2,7 +2,7 @@ module Veewee
   module Provider
     module Core
       module BoxCommand
-        def create_floppy(filename)
+        def create_floppy(floppy_filename)
           # Todo Check for java
           # Todo check output of commands
 
@@ -15,7 +15,7 @@ module Veewee
               FileUtils.cp("#{full_filename}","#{temp_dir}")
             end
             javacode_dir=File.expand_path(File.join(__FILE__,'..','..','..','..','..','java'))
-            floppy_file=File.join(definition.path,filename)
+            floppy_file=File.join(definition.path,floppy_filename)
             if File.exists?(floppy_file)
               env.logger.info "Removing previous floppy file"
               FileUtils.rm(floppy_file)


### PR DESCRIPTION
Hi. 

Stumbled upon an issue when virtualfloppy.vfd was never created. Instead, the last file from definition.floppy_files was used as the target for the floppy (see log [1] is below). The trivial fix is in the pull request.

Regards,
Konstantin

[1]

Fri Aug 03 09:54:51 +0200 2012 -  - [veewee] -------
Fri Aug 03 09:54:52 +0200 2012 -  - [veewee] Removing previous floppy file
Fri Aug 03 09:54:52 +0200 2012 -  - [veewee] Command: "java -jar /Users/konstan/SixSq/code/veewee/lib/java/dir2floppy.jar "/var/folders/8s/ct1psdgd7618_5_n_8clwdhm0000gn/T/d20120803-6653-kqp1mj" "/Users/konstan/SixSq/code/veewee/definitions/windows-7-pro-amd64-root/install-cygwin-sshd.bat""
Fri Aug 03 09:54:52 +0200 2012 -  - [veewee] Output:
Fri Aug 03 09:54:52 +0200 2012 -  - [veewee] -------
Fri Aug 03 09:54:53 +0200 2012 -  - [veewee] - Processing file: Autounattend.xml ..........
Fri Aug 03 09:54:53 +0200 2012 -  - [veewee] - Processing file: install-cygwin-sshd.bat ..
Fri Aug 03 09:54:53 +0200 2012 -  - [veewee] - Processing file: install-winrm.bat .
Fri Aug 03 09:54:53 +0200 2012 -  - [veewee] - Processing file: oracle-cert.cer ..
Fri Aug 03 09:54:53 +0200 2012 -  - [veewee] Done
Fri Aug 03 09:54:53 +0200 2012 -  - [veewee] Command: "VBoxManage storagectl "windows-7-pro-amd64-root" --name "Floppy Controller" --add floppy"
Fri Aug 03 09:54:53 +0200 2012 -  - [veewee] Output:
Fri Aug 03 09:54:53 +0200 2012 -  - [veewee] -------
Fri Aug 03 09:54:54 +0200 2012 -  - [veewee] Command: "VBoxManage storageattach "windows-7-pro-amd64-root" --storagectl "Floppy Controller" --port 0 --device 0 --type fdd --medium "/Users/konstan/SixSq/code/veewee/definitions/windows-7-pro-amd64-root/virtualfloppy.vfd""
Fri Aug 03 09:54:54 +0200 2012 -  - [veewee] Output:
Fri Aug 03 09:54:54 +0200 2012 -  - [veewee] -------
Fri Aug 03 09:54:54 +0200 2012 -  - [veewee] VBoxManage: error: Could not find file for the medium '/Users/konstan/SixSq/code/veewee/definitions/windows-7-pro-amd64-root/virtualfloppy.vfd' (VERR_FILE_NOT_FOUND)
Fri Aug 03 09:54:54 +0200 2012 -  - [veewee] VBoxManage: error: Details: code VBOX_E_FILE_ERROR (0x80bb0004), component Medium, interface IMedium, callee nsISupports
Fri Aug 03 09:54:54 +0200 2012 -  - [veewee] Context: "OpenMedium(Bstr(pszFilenameOrUuid).raw(), enmDevType, AccessMode_ReadWrite, fForceNewUuidOnOpen, pMedium.asOutParam())" at line 210 of file VBoxManageDisk.cpp
Fri Aug 03 09:54:54 +0200 2012 -  - [veewee] VBoxManage: error: Invalid UUID or filename "/Users/konstan/SixSq/code/veewee/definitions/windows-7-pro-amd64-root/virtualfloppy.vfd"
Error: We executed a shell command and the exit status was not 0
- Command :VBoxManage storageattach "windows-7-pro-amd64-root" --storagectl "Floppy Controller" --port 0 --device 0 --type fdd --medium "/Users/konstan/SixSq/code/veewee/definitions/windows-7-pro-amd64-root/virtualfloppy.vfd".
- Exitcode :1.
- Output   :
  VBoxManage: error: Could not find file for the medium '/Users/konstan/SixSq/code/veewee/definitions/windows-7-pro-amd64-root/virtualfloppy.vfd' (VERR_FILE_NOT_FOUND)
  VBoxManage: error: Details: code VBOX_E_FILE_ERROR (0x80bb0004), component Medium, interface IMedium, callee nsISupports
  Context: "OpenMedium(Bstr(pszFilenameOrUuid).raw(), enmDevType, AccessMode_ReadWrite, fForceNewUuidOnOpen, pMedium.asOutParam())" at line 210 of file VBoxManageDisk.cpp
  VBoxManage: error: Invalid UUID or filename "/Users/konstan/SixSq/code/veewee/definitions/windows-7-pro-amd64-root/virtualfloppy.vfd"

Wrong exit code for command VBoxManage storageattach "windows-7-pro-amd64-root" --storagectl "Floppy Controller" --port 0 --device 0 --type fdd --medium "/Users/konstan/SixSq/code/veewee/definitions/windows-7-pro-amd64-root/virtualfloppy.vfd"
veewee konstan$ 
