### PR TITLE
CentOS 6.2 has been deprecated and moved to vault.centos.org

### DIFF
--- a/templates/CentOS-6.2-i386-minimal/definition.rb
+++ b/templates/CentOS-6.2-i386-minimal/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.2-i386-minimal.iso",
-  :iso_src => "http://ftp.yz.yamagata-u.ac.jp/pub/linux/centos/6.2/isos/i386/CentOS-6.2-i386-minimal.iso",
+  :iso_src => "http://vault.centos.org/6.2/isos/i386/CentOS-6.2-i386-minimal.iso",
   :iso_md5 => "cc4fbd16bd305f5bf6731b4b10f8fd18",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/templates/CentOS-6.2-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.2-x86_64-minimal/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.2-x86_64-minimal.iso",
-  :iso_src => "http://centos.weepeetelecom.be/6.2/isos/x86_64/CentOS-6.2-x86_64-minimal.iso",
+  :iso_src => "http://vault.centos.org/6.2/isos/x86_64/CentOS-6.2-x86_64-minimal.iso",
   :iso_md5 => "20dac370a6e08ded2701e4104855bc6e",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/templates/CentOS-6.2-x86_64-netboot/definition.rb
+++ b/templates/CentOS-6.2-x86_64-netboot/definition.rb
@@ -8,7 +8,7 @@ Veewee::Definition.declare({
   :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.2-x86_64-netinstall.iso",
-  :iso_src => "http://be.mirror.eurid.eu/centos/6.2/isos/x86_64/CentOS-6.2-x86_64-netinstall.iso",
+  :iso_src => "http://vault.centos.org/6.2/isos/x86_64/CentOS-6.2-x86_64-netinstall.iso",
   :iso_md5 => "7e7f4161a5c8c49032655e5f4ecd1f07",
   :iso_download_timeout => 1000,
   :boot_wait => "15",


### PR DESCRIPTION
Corrected download paths for CentOS 6.2 ISOs
