### PR TITLE
Remove zypper locks on removed packages to avoid later dependency problems

### DIFF
--- a/templates/SLES-11-SP1-DVD-i586-GM/postinstall.sh
+++ b/templates/SLES-11-SP1-DVD-i586-GM/postinstall.sh
@@ -4,6 +4,9 @@
 
 date > /etc/vagrant_box_build_time
 
+# remove zypper locks on removed packages to avoid later dependency problems
+zypper --non-interactive rl  \*
+
 # install vagrant key
 echo -e "\ninstall vagrant key ..."
 mkdir -m 0700 /home/vagrant/.ssh

--- a/templates/SLES-11-SP1-DVD-x86_64-GM/postinstall.sh
+++ b/templates/SLES-11-SP1-DVD-x86_64-GM/postinstall.sh
@@ -4,6 +4,9 @@
 
 date > /etc/vagrant_box_build_time
 
+# remove zypper locks on removed packages to avoid later dependency problems
+zypper --non-interactive rl  \*
+
 # install vagrant key
 echo -e "\ninstall vagrant key ..."
 mkdir -m 0700 /home/vagrant/.ssh


### PR DESCRIPTION
Every package, which is removed from the minimal installation in AutoYast, will be locked by zypper. Later, when using the image, you get strange zypper dependency problems when you want to reinstall one of the packages. The zypper error messages do not tell you that the removed packages are just locked.
