### PR TITLE
Expand ostypes.yml for Fusion

### DIFF
--- a/lib/veewee/config/ostypes.yml
+++ b/lib/veewee/config/ostypes.yml
@@ -134,6 +134,16 @@ Debian_64:
   :kvm:
   :vbox: Debian_64
   :parallels: debian
+Debian6:
+  :fusion: debian6
+  :kvm:
+  :vbox: Debian
+  :parallels: debian
+Debian6_64:
+  :fusion: debian6-64
+  :kvm:
+  :vbox: Debian_64
+  :parallels: debian
 Gentoo:
   :fusion: other26xlinux
   :kvm:
@@ -179,7 +189,27 @@ RedHat_64:
   :kvm:
   :vbox: RedHat_64
   :parallels: redhat
-Centos4:
+RedHat5:
+  :fusion: rhel5
+  :kvm:
+  :vbox: RedHat
+  :parallels: redhat
+RedHat5_64:
+  :fusion: rhel5-64
+  :kvm:
+  :vbox: RedHat_64
+  :parallels: redhat
+RedHat6:
+  :fusion: rhel6
+  :kvm:
+  :vbox: RedHat
+  :parallels: redhat
+RedHat6_64:
+  :fusion: rhel6-64
+  :kvm:
+  :vbox: RedHat_64
+  :parallels: redhat
+Centos:
   :fusion: centos
   :kvm:
   :vbox: RedHat
@@ -219,6 +249,10 @@ SUSE_64:
   :kvm:
   :vbox: OpenSUSE_64
   :parallels: suse
+SLES11:
+  :fusion: sles11
+SLES11_64:
+  :fusion: sles11-64
 Fedora:
   :fusion: fedora
   :kvm:


### PR DESCRIPTION
Fixed Typo: 'Centos4' to 'Centos'.
Added Fusion type, rhel5 and rhel6.
Added Fusion type, SLES11.
Added Debian6.
