### PR TITLE
Add :disk_variant option for VirtualBox provider.

### DIFF
--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -17,7 +17,7 @@ this is essentially making a copy based on the  templates provided above.
 
     Veewee::Definition.declare( {
     :cpu_count => '1', :memory_size=> '256', 
-    :disk_size => '10140', :disk_format => 'VDI',
+    :disk_size => '10140', :disk_format => 'VDI', :disk_variant => 'Standard',
     :os_type_id => 'Ubuntu',
     :iso_file => "ubuntu-10.10-server-i386.iso", 
     :iso_src => "http://releases.ubuntu.com/maverick/ubuntu-10.10-server-i386.iso",

--- a/lib/veewee/definition.rb
+++ b/lib/veewee/definition.rb
@@ -11,7 +11,7 @@ module Veewee
     attr_accessor :path
 
     attr_accessor :cpu_count,:memory_size,:iso_file
-    attr_accessor :disk_size, :disk_format
+    attr_accessor :disk_size, :disk_format, :disk_variant
 
     attr_accessor :os_type_id
 
@@ -72,7 +72,7 @@ module Veewee
       @postinstall_files=[]; @postinstall_timeout = 10000;
 
       @iso_file=""
-      @disk_size = '10240'; @disk_format = 'VDI'
+      @disk_size = '10240'; @disk_format = 'VDI'; @disk_variant = 'Standard'
 
       #        :hostiocache => 'off' ,
       #        :os_type_id => 'Ubuntu',

--- a/lib/veewee/provider/virtualbox/box/helper/create.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/create.rb
@@ -66,11 +66,11 @@ module Veewee
 
 
         def create_disk
-            ui.info "Creating new harddrive of size #{definition.disk_size.to_i} "
+            ui.info "Creating new harddrive of size #{definition.disk_size.to_i}, format #{definition.disk_format}, variant #{definition.disk_variant} "
 
 
             place=get_vbox_home
-            command ="#{@vboxcmd} createhd --filename \"#{File.join(place,name,name+"."+definition.disk_format.downcase)}\" --size \"#{definition.disk_size.to_i}\" --format #{definition.disk_format.downcase}"
+            command ="#{@vboxcmd} createhd --filename \"#{File.join(place,name,name+"."+definition.disk_format.downcase)}\" --size \"#{definition.disk_size.to_i}\" --format #{definition.disk_format.downcase} --variant #{definition.disk_variant.downcase}"
             shell_exec("#{command}")
 
         end


### PR DESCRIPTION
Dynamically allocated disks are fast at creation time, but
rather slow when working with them. 'VBoxManage createhd' supports the
--variant flag which allows to create disks with fixed storage
allocation ('Fixed' for the :disk_variant option here). We keep
dynamically allocated storage ('Standard') as the default option.

Signed-off-by: Thorsten Fischer thorsten@froschi.org
