### PR TITLE
fixed groups for Debian 6.0.4/6.0.5:

### DIFF
--- a/templates/Debian-6.0.4-amd64-netboot/vagrant.sh
+++ b/templates/Debian-6.0.4-amd64-netboot/vagrant.sh
@@ -2,8 +2,12 @@
 
 date > /etc/vagrant_box_build_time
 
+# Add groups puppet and chef
+groupadd puppet
+groupadd chef
+
 # Create the user vagrant with password vagrant
-useradd -G admin -p $(perl -e'print crypt("vagrant", "vagrant")') -m -s /bin/bash -N vagrant
+useradd -G sudo -p $(perl -e'print crypt("vagrant", "vagrant")') -m -s /bin/bash -N vagrant
 
 # Install vagrant keys
 mkdir -pm 700 /home/vagrant/.ssh

--- a/templates/Debian-6.0.4-i386-netboot/vagrant.sh
+++ b/templates/Debian-6.0.4-i386-netboot/vagrant.sh
@@ -2,8 +2,12 @@
 
 date > /etc/vagrant_box_build_time
 
+# Add groups puppet and chef
+groupadd puppet
+groupadd chef
+
 # Create the user vagrant with password vagrant
-useradd -G admin -p $(perl -e'print crypt("vagrant", "vagrant")') -m -s /bin/bash -N vagrant
+useradd -G sudo -p $(perl -e'print crypt("vagrant", "vagrant")') -m -s /bin/bash -N vagrant
 
 # Install vagrant keys
 mkdir -pm 700 /home/vagrant/.ssh

--- a/templates/Debian-6.0.5-amd64-netboot/vagrant.sh
+++ b/templates/Debian-6.0.5-amd64-netboot/vagrant.sh
@@ -2,8 +2,12 @@
 
 date > /etc/vagrant_box_build_time
 
+# Add groups puppet and chef
+groupadd puppet
+groupadd chef
+
 # Create the user vagrant with password vagrant
-useradd -G admin -p $(perl -e'print crypt("vagrant", "vagrant")') -m -s /bin/bash -N vagrant
+useradd -G sudo -p $(perl -e'print crypt("vagrant", "vagrant")') -m -s /bin/bash -N vagrant
 
 # Install vagrant keys
 mkdir -pm 700 /home/vagrant/.ssh

--- a/templates/Debian-6.0.5-i386-netboot/vagrant.sh
+++ b/templates/Debian-6.0.5-i386-netboot/vagrant.sh
@@ -2,8 +2,12 @@
 
 date > /etc/vagrant_box_build_time
 
+# Add groups puppet and chef
+groupadd puppet
+groupadd chef
+
 # Create the user vagrant with password vagrant
-useradd -G admin -p $(perl -e'print crypt("vagrant", "vagrant")') -m -s /bin/bash -N vagrant
+useradd -G sudo -p $(perl -e'print crypt("vagrant", "vagrant")') -m -s /bin/bash -N vagrant
 
 # Install vagrant keys
 mkdir -pm 700 /home/vagrant/.ssh


### PR DESCRIPTION
fixed groups for Debian 6.0.4/6.0.5:
- groupadd for puppet (and chef) : puppet group is necessary, otherwise on the first launch a series of errors are generated (e.g. “Could not evaluate: Could not find group puppet”)
- 'admin' is not a Debian group (it's a Ubuntu group) ... changed to (existing) group 'sudo'
