### PR TITLE
Fix typo in FreeBSD_64 OS type

### DIFF
--- a/lib/veewee/config/ostypes.yml
+++ b/lib/veewee/config/ostypes.yml
@@ -112,7 +112,7 @@ FreeBSD:
 FreeBSD_64:
   :fusion: FreeBSD_64
   :kvm:
-  :vbox: FreeBSD-64
+  :vbox: FreeBSD_64
   :parallels: freebsd
 Oracle:
   :fusion: oraclelinux


### PR DESCRIPTION
The correct OS type for FreeBSD (64 bit) is FreeBSD_64, not FreeBSD-64. This issue was discovered while experimenting with Opscode's Bento project.

```
[freebsd-9.0] Error: We executed a shell command and the exit status was not 0
[freebsd-9.0] - Command :VBoxManage createvm --name "freebsd-9.0" --ostype "FreeBSD-64" --register.
[freebsd-9.0] - Exitcode :1.
[freebsd-9.0] - Output   :
VBoxManage: error: Guest OS type 'FreeBSD-64' is invalid
VBoxManage: error: Details: code VBOX_E_OBJECT_NOT_FOUND (0x80bb0001), component VirtualBox, interface IVirtualBox, callee nsISupports
Context: "CreateMachine(bstrSettingsFile.raw(), name.raw(), osTypeId.raw(), Guid(id).toUtf16().raw(), FALSE , machine.asOutParam())" at line 249 of file VBoxManageMisc.cpp

Wrong exit code for command VBoxManage createvm --name "freebsd-9.0" --ostype "FreeBSD-64" --register
```
