### PR TITLE
Debian 5.0 repos now live in archive.debian.org

### DIFF
--- a/templates/Debian-5.0.8-amd64-netboot/preseed.cfg
+++ b/templates/Debian-5.0.8-amd64-netboot/preseed.cfg
@@ -66,7 +66,7 @@ d-i netcfg/wireless_wep string
 # If you select ftp, the mirror/country string does not need to be set.
 #d-i mirror/protocol string ftp
 d-i mirror/country string manual
-d-i mirror/http/hostname string http.us.debian.org
+d-i mirror/http/hostname string archive.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 
@@ -206,7 +206,7 @@ d-i passwd/user-default-groups string audio cdrom video admin
 # Select which update services to use; define the mirrors to be used.
 # Values shown below are the normal defaults.
 #d-i apt-setup/services-select multiselect security, volatile
-#d-i apt-setup/security_host string security.debian.org
+d-i apt-setup/security_host string archive.debian.org/debian-security
 #d-i apt-setup/volatile_host string volatile.debian.org
 
 

--- a/templates/Debian-5.0.8-i386-netboot/preseed.cfg
+++ b/templates/Debian-5.0.8-i386-netboot/preseed.cfg
@@ -66,7 +66,7 @@ d-i netcfg/wireless_wep string
 # If you select ftp, the mirror/country string does not need to be set.
 #d-i mirror/protocol string ftp
 d-i mirror/country string manual
-d-i mirror/http/hostname string http.us.debian.org
+d-i mirror/http/hostname string archive.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 
@@ -206,7 +206,7 @@ d-i passwd/user-default-groups string audio cdrom video admin
 # Select which update services to use; define the mirrors to be used.
 # Values shown below are the normal defaults.
 #d-i apt-setup/services-select multiselect security, volatile
-#d-i apt-setup/security_host string security.debian.org
+d-i apt-setup/security_host string archive.debian.org/debian-security
 #d-i apt-setup/volatile_host string volatile.debian.org
 
 


### PR DESCRIPTION
Debian 5.0 Lenny is deprecated and now hosted at archive.debian.org

Without this fix installing Debian 5.0 requires manual intervention: acknowledging "repo not found" warnings and changing /etc/apt/sources.list after install.

(separated from pull request #358 and rebased on top of recent commits)
