### PR TITLE
Make IP retrieval more reliable

### DIFF
--- a/lib/veewee/provider/kvm/box/helper/ip.rb
+++ b/lib/veewee/provider/kvm/box/helper/ip.rb
@@ -4,7 +4,7 @@ module Veewee
       module BoxCommand
         def ip_address
           ip=@connection.servers.all(:name => "#{name}").first.public_ip_address
-          return ip.first unless ip.nil?
+          return [*ip].first unless ip.nil?
           return ip
         end
 


### PR DESCRIPTION
Previous to this commit, the public IP returned from ruby-libvirt may
not be an array. The code assumes it's an array and always grabs the
first item.  I'm not sure if it's ever an array, but to be safe this
commit ensures what's returned from #public_ip_address is an array, then
the first item is selected.
