### PR TITLE
Removed dependency on vagrant home folder

### DIFF
--- a/templates/Debian-6.0.5-i386-netboot/virtualbox.sh
+++ b/templates/Debian-6.0.5-i386-netboot/virtualbox.sh
@@ -5,7 +5,7 @@ if test -f .vbox_version ; then
   aptitude -y purge virtualbox-ose-guest-x11 virtualbox-ose-guest-dkms virtualbox-ose-guest-utils
 
   # Install the VirtualBox guest additions
-  VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+  VBOX_VERSION=$(cat .vbox_version)
   VBOX_ISO=VBoxGuestAdditions_$VBOX_VERSION.iso
   mount -o loop $VBOX_ISO /mnt
   yes|sh /mnt/VBoxLinuxAdditions.run


### PR DESCRIPTION
The script should not depend on the /home/vagrant folder, because the ssh used can be changed in the definitions.rb
