### PR TITLE
Add patch for OSX 4.2.1 GuestAdditions version case

### DIFF
--- a/lib/veewee/provider/virtualbox/box/helper/buildinfo.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/buildinfo.rb
@@ -14,7 +14,7 @@ module Veewee
          #
          def transfer_buildinfo(options)
            super(options)
-           iso_image="VBoxGuestAdditions_#{self.vbox_version}.iso"
+           iso_image="VBoxGuestAdditions_#{self.vboxga_version}.iso"
            env.logger.info "About to transfer virtualbox guest additions iso to the box #{name} - #{ip_address} - #{ssh_options}"
            self.scp("#{File.join(env.config.veewee.iso_dir,iso_image)}",File.basename(iso_image))
          end

--- a/lib/veewee/provider/virtualbox/box/helper/create.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/create.rb
@@ -98,7 +98,7 @@ module Veewee
         end
 
         def attach_guest_additions
-          full_iso_file=File.join(env.config.veewee.iso_dir,"VBoxGuestAdditions_#{self.vbox_version}.iso")
+          full_iso_file=File.join(env.config.veewee.iso_dir,"VBoxGuestAdditions_#{self.vboxga_version}.iso")
           ui.info "Mounting guest additions: #{full_iso_file}"
           command ="#{@vboxcmd} storageattach \"#{name}\" --storagectl \"IDE Controller\" --type dvddrive --port 1 --device 0 --medium \"#{full_iso_file}\""
           shell_exec("#{command}")

--- a/lib/veewee/provider/virtualbox/box/helper/guest_additions.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/guest_additions.rb
@@ -4,13 +4,12 @@ module Veewee
       module BoxCommand
 
         def download_vbox_guest_additions_iso(options)
-          version=self.vbox_version
+          version=self.vboxga_version
           isofile="VBoxGuestAdditions_#{version}.iso"
           url="http://download.virtualbox.org/virtualbox/#{version}/#{isofile}"
           ui.info "Downloading vbox guest additions iso v #{version} - #{url}"
           download_iso(url,isofile)
         end
-
       end
     end
   end

--- a/lib/veewee/provider/virtualbox/box/helper/version.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/version.rb
@@ -12,6 +12,13 @@ module Veewee
           return version
         end
 
+        def vboxga_version
+          affected_version?(self.vbox_version) ? "4.2.0" : self.vbox_version
+        end
+      protected
+        def affected_version?(ver)
+          RUBY_PLATFORM.downcase.include?("darwin") && ver == "4.2.1"
+        end
       end
     end
   end

--- a/test/veewee/provider/virtualbox/box/helper/guest_additions_test.rb
+++ b/test/veewee/provider/virtualbox/box/helper/guest_additions_test.rb
@@ -1,0 +1,92 @@
+require 'test/unit'
+require 'veewee/provider/virtualbox/box/helper/guest_additions'
+require 'veewee/provider/virtualbox/box/helper/version'
+require 'logger'
+
+class TestVboxGuestAdditionsHelper < Test::Unit::TestCase
+  include Veewee::Provider::Virtualbox::BoxCommand
+  def setup
+    @fd = IO.sysopen("/dev/null", "w")
+  end
+
+  def ui
+    @ui ||= Logger.new(IO.new(@fd))
+  end
+
+  def test_affected_osx_version_returns_downpatched_ga_version
+    set_ruby_platform("darwin")
+    set_vbox_version("4.2.1")
+    def download_iso(url, isofile)
+      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.2.0/"
+      assert(url.include?(expected_url_prefix))
+      assert_equal("VBoxGuestAdditions_4.2.0.iso", isofile)
+    end
+    download_vbox_guest_additions_iso({})
+  end
+
+  def test_unaffected_osx_version_returns_same_version
+    set_ruby_platform("darwin")
+    set_vbox_version("4.1.22")
+    def download_iso(url, isofile)
+      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.1.22/"
+      assert(url.include?(expected_url_prefix))
+      assert_equal("VBoxGuestAdditions_4.1.22.iso", isofile)
+    end
+    download_vbox_guest_additions_iso({})
+  end
+
+  def test_affected_linux_version_returns_same_version
+    set_ruby_platform("linux")
+    set_vbox_version("4.2.1")
+    def download_iso(url, isofile)
+      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.2.1/"
+      assert(url.include?(expected_url_prefix))
+      assert_equal("VBoxGuestAdditions_4.2.1.iso", isofile)
+    end
+    download_vbox_guest_additions_iso({})
+  end
+
+  def test_unaffected_linux_version_returns_same_version
+    set_ruby_platform("linux")
+    set_vbox_version("4.0.19")
+    def download_iso(url, isofile)
+      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.0.19/"
+      assert(url.include?(expected_url_prefix))
+      assert_equal("VBoxGuestAdditions_4.0.19.iso", isofile)
+    end
+    download_vbox_guest_additions_iso({})
+  end
+
+  def test_affected_mswin_version_returns_same_version
+    set_ruby_platform("mswin")
+    set_vbox_version("4.2.1")
+    def download_iso(url, isofile)
+      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.2.1/"
+      assert(url.include?(expected_url_prefix))
+      assert_equal("VBoxGuestAdditions_4.2.1.iso", isofile)
+    end
+    download_vbox_guest_additions_iso({})
+  end
+
+  def test_unaffected_mswin_version_returns_same_version
+    set_ruby_platform("mswin")
+    set_vbox_version("4.0.19")
+    def download_iso(url, isofile)
+      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.0.19/"
+      assert(url.include?(expected_url_prefix))
+      assert_equal("VBoxGuestAdditions_4.0.19.iso", isofile)
+    end
+    download_vbox_guest_additions_iso({})
+  end
+
+private
+  def set_ruby_platform(platform)
+    Object.const_set("RUBY_PLATFORM", platform)
+  end
+
+  def set_vbox_version(ver)
+    Veewee::Provider::Virtualbox::BoxCommand.send(:define_method, :vbox_version) do
+      ver
+    end
+  end
+end

--- a/test/veewee/provider/virtualbox/box/helper/version.rb
+++ b/test/veewee/provider/virtualbox/box/helper/version.rb
@@ -1,0 +1,54 @@
+require 'test/unit'
+require 'veewee/provider/virtualbox/box/helper/version'
+require 'logger'
+
+class TestVboxGuestAdditionsHelper < Test::Unit::TestCase
+  include Veewee::Provider::Virtualbox::BoxCommand
+
+  def test_affected_osx_version_returns_downpatched_ga_version
+    set_ruby_platform("darwin")
+    set_vbox_version("4.2.1")
+    assert_equal("4.2.0", self.vboxga_version)
+  end
+
+  def test_unaffected_osx_version_returns_same_version
+    set_ruby_platform("darwin")
+    set_vbox_version("4.1.22")
+    assert_equal("4.1.22", self.vboxga_version)
+  end
+
+  def test_affected_linux_version_returns_same_version
+    set_ruby_platform("linux")
+    set_vbox_version("4.2.1")
+    assert_equal("4.2.1", self.vboxga_version)
+  end
+
+  def test_unaffected_linux_version_returns_same_version
+    set_ruby_platform("linux")
+    set_vbox_version("4.0.19")
+    assert_equal("4.0.19", self.vboxga_version)
+  end
+
+  def test_affected_mswin_version_returns_same_version
+    set_ruby_platform("mswin")
+    set_vbox_version("4.2.1")
+    assert_equal("4.2.1", self.vboxga_version)
+  end
+
+  def test_unaffected_mswin_version_returns_same_version
+    set_ruby_platform("mswin")
+    set_vbox_version("4.0.19")
+    assert_equal("4.0.19", self.vboxga_version)
+  end
+
+private
+  def set_ruby_platform(platform)
+    Object.const_set("RUBY_PLATFORM", platform)
+  end
+
+  def set_vbox_version(ver)
+    Veewee::Provider::Virtualbox::BoxCommand.send(:define_method, :vbox_version) do
+      ver
+    end
+  end
+end


### PR DESCRIPTION
Due to VirtualBox's emergency fix of just the OS X version for 4.2.0 with
patch release 4.2.1 and no corresponding GuestAdditions, Veewee is requesting
the incorrect URL and getting a 404 and erroring out. See another user has
reported this issue in jedi4ever/veewee#387.
