### PR TITLE
Ubuntu 12.04 - avoid keyboard settings prompt

### DIFF
--- a/templates/ubuntu-12.04.1-server-amd64/definition.rb
+++ b/templates/ubuntu-12.04.1-server-amd64/definition.rb
@@ -16,7 +16,7 @@ Veewee::Session.declare({
     'debian-installer=en_US auto locale=en_US kbd-chooser/method=us ',
     'hostname=%NAME% ',
     'fb=false debconf/frontend=noninteractive ',
-    'keyboard-configuration/layout=USA keyboard-configuration/variant=USA console-setup/ask_detect=false ',
+    'keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA keyboard-configuration/variant=USA console-setup/ask_detect=false ',
     'initrd=/install/initrd.gz -- <Enter>'
 ],
   :kickstart_port => "7122",


### PR DESCRIPTION
I found that when building an Ubuntu 12.04 boxfile for vagrant (ie. vbox) I was prompted to select keyboard input during the build process.  I would presume that this is not supposed to happen, and it looks like there are various options set in definition.rb for the template to silence those kinds of options.

This change suppresses the prompt for user input during installation for Ubuntu 12.04 amd64.  I would guess that a similar change would be appropriate for the other 12.04 templates too, but I have not tried them to be sure.
