### PR TITLE
added support for shift

### DIFF
--- a/lib/veewee/provider/core/box/vnc.rb
+++ b/lib/veewee/provider/core/box/vnc.rb
@@ -76,6 +76,7 @@ module Veewee
         special['<Left>'] = :left
         special['<Right>'] = :right
         special['<Home>'] = :home
+        special['<Shift>'] = :shift
 
         special['<F1>'] = :f1
         special['<F2>'] = :f2


### PR DESCRIPTION
I want to use sed in :boot_cmd_sequence to change key creation for sshd - and I need '{', '}', '^', '$', '#'. These can't be typed without shift (though adding shift is only a rather inconvenient workaround).
