### PR TITLE
add scancodes programmatically

### DIFF
--- a/lib/veewee/provider/core/helper/scancode.rb
+++ b/lib/veewee/provider/core/helper/scancode.rb
@@ -8,44 +8,35 @@ module Veewee
 
             #http://www.win.tue.nl/~aeb/linux/kbd/scancodes-1.html
 
-            k=Hash.new
-            k['1'] = '02 82' ; k['2'] = '03 83' ; k['3'] = '04 84'; k['4']= '05 85' ;
-            k['5']='06 86'; k['6'] = '07 87' ; k['7'] = '08 88'; k['8'] = '09 89'; k['9']= '0a 8a';
-            k['0']='0b 8b'; k['-'] = '0c 8c'; k['='] = '0d 8d' ;
-            k['Tab'] = '0f 8f';
-            k['q']  = '10 90' ;       k['w']  = '11 91' ;       k['e']  = '12 92';
-            k['r'] = '13 93'       ; k['t'] = '14 94'       ; k['y'] = '15 95';
-            k['u']= '16 96'        ; k['i']='17 97';      k['o'] = '18 98'       ; k['p'] = '19 99' ;
+            # keycode hash, seeded with 'Tab' - which is special as it's longer than 1 char
+            k = { 'Tab' => '0f 8f' }
+            
+            # add keycodes
 
-            k['Q']  = '2a 10 aa 90' ; k['W']  = '2a 11 aa 91' ; k['E']  = '2a 12 aa 92'; k['R'] = '2a 13 aa 93' ; k['T'] = '2a 14 aa 94' ; k['Y'] = '2a 15 aa 95'; k['U']= '2a 16 aa 96' ; k['I']='2a 17 aa 97'; k['O'] = '2a 18 aa 98' ; k['P'] = '2a 19 aa 99' ;
+            # "pure" keys (no modifier keys)
+            lower_keys = {
+              '1234567890-='  => 0x02,
+              'qwertyuiop[]'  => 0x10,
+              'asdfghjkl;\'`' => 0x1e,
+              '\\zxcvbnm,./'  => 0x2b
+            }.each do |keys, offset|
+              keys.split('').each_with_index do |key, idx|
+                k[key] = sprintf('%02x %02x', idx + offset, idx + offset + 0x80)
+              end
+            end
 
-            k['a'] = '1e 9e'; k['s']  = '1f 9f' ; k['d']  = '20 a0' ; k['f']  = '21 a1'; k['g'] = '22 a2' ; k['h'] = '23 a3' ; k['j'] = '24 a4';
-            k['k']= '25 a5' ; k['l']='26 a6';
-            k['A'] = '2a 1e aa 9e'; k['S']  = '2a 1f aa 9f' ; k['D']  = '2a 20 aa a0' ; k['F']  = '2a 21 aa a1';
-            k['G'] = '2a 22 aa a2' ; k['H'] = '2a 23 aa a3' ; k['J'] = '2a 24 aa a4'; k['K']= '2a 25 aa a5' ; k['L']='2a 26 aa a6';
-
-            k[';'] = '27 a7' ;k['"']='2a 28 aa a8';k['\'']='28 a8';
-
-            k['\\'] = '2b ab';   k['|'] = '2a 2b aa 8b';
-
-            k['[']='1a 9a'; k[']']='1b 9b';
-            k['<']='2a 33 aa b3'; k['>']='2a 34 aa b4';
-            k['$']='2a 05 aa 85';
-            k['+']='2a 0d aa 8d';
-
-            k['?']='2a 35 aa b5';
-            k['z'] = '2c ac'; k['x']  = '2d ad' ; k['c']  = '2e ae' ; k['v']  = '2f af'; k['b'] = '30 b0' ; k['n'] = '31 b1' ;
-            k['m'] = '32 b2';
-            k['Z'] = '2a 2c aa ac'; k['X']  = '2a 2d aa ad' ; k['C']  = '2a 2e aa ae' ; k['V']  = '2a 2f aa af';
-            k['B'] = '2a 30 aa b0' ; k['N'] = '2a 31 aa b1' ; k['M'] = '2a 32 aa b2';
-
-            k[',']= '33 b3' ; k['.']='34 b4'; k['/'] = '35 b5' ;k[':'] = '2a 27 aa a7';
-            k['%'] = '2a 06 aa 86';  k['_'] = '2a 0c aa 8c';
-            k['&'] = '2a 08 aa 88';
-            k['('] = '2a 0a aa 8a';
-            k[')'] = '2a 0b aa 8b';
-
-
+            # upcase keys (with shift)
+            {
+              '!@#$%^&*()_+'  => 0x02,
+              'QWERTYUIOP{}'  => 0x10,
+              'ASDFGHJKL:"~'  => 0x1e,
+              '|ZXCVBNM<>?'   => 0x2b
+            }.each do |keys, offset|
+              keys.split('').each_with_index do |key, idx|
+                k[key] = sprintf('2a %02x aa %02x', idx + offset, idx + offset + 0x80)
+              end
+            end
+            
             special=Hash.new;
             special['<Enter>'] = '1c 9c';
             special['<Backspace>'] = '0e 8e';
@@ -67,16 +58,8 @@ module Veewee
             special['<Right>'] = '4d cd';
             special['<Home>'] = '47 c7';
 
-            special['<F1>'] = '3b';
-            special['<F2>'] = '3c';
-            special['<F3>'] = '3d';
-            special['<F4>'] = '3e';
-            special['<F5>'] = '3f';
-            special['<F6>'] = '40';
-            special['<F7>'] = '41';
-            special['<F8>'] = '42';
-            special['<F9>'] = '43';
-            special['<F10>'] = '44';
+            # F1 .. F10
+            (1..10).each { |num| special["<F#{num}>"] = sprintf('%02x', num + 0x3a) }
 
             keycodes=''
             thestring.gsub!(/ /,"<Spacebar>")


### PR DESCRIPTION
I changed it from a declaration of each and every scancode to a generation - at least for every scancode in `k` and F1..F10 in `special`.
I probably fixed at least one copy&paste error by doing so ( `|` was written as using a key release code of `8b` instead of `ab` ).
I didn't test every scancode I added, but I kept to the website in the comment and tested it by building a basebox and using sed with a regexp in `:boot_cmd_sequence`.
