### PR TITLE
Prevent "validate" error on sudo

### DIFF
--- a/validation/features/steps/veewee_steps.rb
+++ b/validation/features/steps/veewee_steps.rb
@@ -9,7 +9,7 @@ Given /^a veeweebox was build$/ do
 end
 
 When /^I sudorun "([^\"]*)" over ssh$/ do |command|
-  @box.exec("echo '#{command}' > /tmp/validation.sh")
+  @box.exec("echo '#{command}' > /tmp/validation.sh && chmod a+x /tmp/validation.sh")
   @sshresult=@box.exec(@box.sudo("/tmp/validation.sh"))
 end
 


### PR DESCRIPTION
Validate prints "unexpected exit code" and a stacktrace on the "sudo whoami" step.
This is caused by insufficient permissions on /tmp/validation.sh - when it is written, the "execute" flag is not set.
I added a chmod after file creation to fix the permissions.
