### PR TITLE
Add option use_sata to control whether to use SATA or IDE for main disk

### DIFF
--- a/lib/veewee/definition.rb
+++ b/lib/veewee/definition.rb
@@ -31,7 +31,7 @@ module Veewee
     attr_accessor :floppy_files
 
 
-    attr_accessor :use_hw_virt_ext,:use_pae,:hostiocache
+    attr_accessor :use_hw_virt_ext,:use_pae,:hostiocache, :use_sata
 
     attr_accessor :iso_dowload_timeout, :iso_src,:iso_md5 ,:iso_download_instructions
 
@@ -73,6 +73,7 @@ module Veewee
 
       @iso_file=""
       @disk_size = '10240'; @disk_format = 'VDI'; @disk_variant = 'Standard'
+      @use_sata = true
 
       #        :hostiocache => 'off' ,
       #        :os_type_id => 'Ubuntu',

--- a/lib/veewee/provider/virtualbox/box/create.rb
+++ b/lib/veewee/provider/virtualbox/box/create.rb
@@ -36,12 +36,24 @@ module Veewee
           #Create a disk with the same name as the box_name
           self.create_disk
 
-          self.add_ide_controller
-          self.attach_isofile
-          self.attach_guest_additions
+          use_sata = definition.use_sata
+          if use_sata
+            disk_device_number = 0
+            isofile_ide_device_number = 0
+          else
+            disk_device_number = 0
+            isofile_ide_device_number = 1
+          end
 
-          self.add_sata_controller
-          self.attach_disk
+          self.add_ide_controller
+          if use_sata
+            self.add_sata_controller
+            self.attach_disk_sata(disk_device_number)
+          else
+            self.attach_disk_ide(disk_device_number)
+          end
+          self.attach_isofile(isofile_ide_device_number)
+          self.attach_guest_additions
 
           self.create_floppy("virtualfloppy.vfd")
 

--- a/lib/veewee/provider/virtualbox/box/helper/create.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/create.rb
@@ -75,8 +75,7 @@ module Veewee
 
         end
 
-        def attach_disk
-
+        def attach_disk_common(storagectl, device_number)
           place=get_vbox_home
           location=name+"."+definition.disk_format.downcase
 
@@ -84,16 +83,23 @@ module Veewee
           ui.info "Attaching disk: #{location}"
 
           #command => "${vboxcmd} storageattach \"${vname}\" --storagectl \"SATA Controller\" --port 0 --device 0 --type hdd --medium \"${vname}.vdi\"",
-          command ="#{@vboxcmd} storageattach \"#{name}\" --storagectl \"SATA Controller\" --port 0 --device 0 --type hdd --medium \"#{location}\""
+          command ="#{@vboxcmd} storageattach \"#{name}\" --storagectl \"#{storagectl}\" --port 0 --device #{device_number} --type hdd --medium \"#{location}\""
           shell_exec("#{command}")
+        end
 
+        def attach_disk_ide(device_number=0)
+          self.attach_disk_common("IDE Controller", device_number)
+        end
+
+        def attach_disk_sata(device_number=0)
+          self.attach_disk_common("SATA Controller", device_number)
         end
 
 
-        def attach_isofile
+        def attach_isofile(device_number=0)
           full_iso_file=File.join(env.config.veewee.iso_dir,definition.iso_file)
           ui.info "Mounting cdrom: #{full_iso_file}"
-          command ="#{@vboxcmd} storageattach \"#{name}\" --storagectl \"IDE Controller\" --type dvddrive --port 0 --device 0 --medium \"#{full_iso_file}\""
+          command ="#{@vboxcmd} storageattach \"#{name}\" --storagectl \"IDE Controller\" --type dvddrive --port 0 --device #{device_number} --medium \"#{full_iso_file}\""
           shell_exec("#{command}")
         end
 


### PR DESCRIPTION
If :use_sata is set to false in definition.rb, veewee will attach the disk to the IDE controller and will not create a SATA controller at all.

This is a first step toward supporting windows XP in veewee, which does not support SATA out of the box. Once this is integrated, I will submit another PR that contains a basic template for windows XP.
