### PR TITLE
fix osx 4.1.23 ga version mismatch

### DIFF
--- a/lib/veewee/provider/virtualbox/box/helper/version.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/version.rb
@@ -2,6 +2,7 @@ module Veewee
   module Provider
     module Virtualbox
       module BoxCommand
+        UNSYNCED_VERSIONS = {"4.2.1" => "4.2.0", "4.1.23" => "4.1.22"}
 
         # Return the major/minor/incremental version of VirtualBox.
         # For example: 4.1.8_Debianr75467 -> 4.1.8
@@ -13,11 +14,11 @@ module Veewee
         end
 
         def vboxga_version
-          affected_version?(self.vbox_version) ? "4.2.0" : self.vbox_version
+          affected_version?(self.vbox_version) ? UNSYNCED_VERSIONS[self.vbox_version] : self.vbox_version
         end
       protected
         def affected_version?(ver)
-          RUBY_PLATFORM.downcase.include?("darwin") && ver == "4.2.1"
+          RUBY_PLATFORM.downcase.include?("darwin") && UNSYNCED_VERSIONS.has_key?(ver)
         end
       end
     end

--- a/test/veewee/provider/virtualbox/box/helper/guest_additions_test.rb
+++ b/test/veewee/provider/virtualbox/box/helper/guest_additions_test.rb
@@ -13,70 +13,73 @@ class TestVboxGuestAdditionsHelper < Test::Unit::TestCase
     @ui ||= Logger.new(IO.new(@fd))
   end
 
+  def affected_versions
+    {
+      "4.2.1" => "4.2.0",
+      "4.1.23" => "4.1.22"
+    }
+  end
+
+  def verify_version(vbox_version, guest_version, msg="", scope)
+    set_vbox_version(vbox_version)
+
+    scope.class.instance_eval do
+      define_method :download_iso do |url, isofile|
+        expected_url_prefix = "http://download.virtualbox.org/virtualbox/#{guest_version}/"
+
+        assert(url.include?(expected_url_prefix), msg)
+        assert_equal("VBoxGuestAdditions_#{guest_version}.iso", isofile, msg)
+      end
+    end
+
+    download_vbox_guest_additions_iso({})
+  end
+
+  def verify_affected_versions(msg="", scope)
+    affected_versions.each do |vbox_version, guest_version|
+      verify_version(vbox_version, guest_version, msg, scope)
+    end
+  end
+
   def test_affected_osx_version_returns_downpatched_ga_version
     set_ruby_platform("darwin")
-    set_vbox_version("4.2.1")
-    def download_iso(url, isofile)
-      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.2.0/"
-      assert(url.include?(expected_url_prefix))
-      assert_equal("VBoxGuestAdditions_4.2.0.iso", isofile)
-    end
-    download_vbox_guest_additions_iso({})
+    msg = "affected osx version did not return downpatched ga version"
+
+    verify_affected_versions(msg, self)
   end
 
   def test_unaffected_osx_version_returns_same_version
     set_ruby_platform("darwin")
-    set_vbox_version("4.1.22")
-    def download_iso(url, isofile)
-      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.1.22/"
-      assert(url.include?(expected_url_prefix))
-      assert_equal("VBoxGuestAdditions_4.1.22.iso", isofile)
-    end
-    download_vbox_guest_additions_iso({})
+    msg = "unaffected osx version did not return same version"
+    verify_version("4.1.22","4.1.22", msg, self)
   end
 
   def test_affected_linux_version_returns_same_version
     set_ruby_platform("linux")
-    set_vbox_version("4.2.1")
-    def download_iso(url, isofile)
-      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.2.1/"
-      assert(url.include?(expected_url_prefix))
-      assert_equal("VBoxGuestAdditions_4.2.1.iso", isofile)
+    msg = "affected linux version did not return same version"
+    affected_versions.keys.each do |version|
+      verify_version(version, version, msg, self)
     end
-    download_vbox_guest_additions_iso({})
   end
 
   def test_unaffected_linux_version_returns_same_version
     set_ruby_platform("linux")
-    set_vbox_version("4.0.19")
-    def download_iso(url, isofile)
-      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.0.19/"
-      assert(url.include?(expected_url_prefix))
-      assert_equal("VBoxGuestAdditions_4.0.19.iso", isofile)
-    end
-    download_vbox_guest_additions_iso({})
+    msg = "unaffected linux version did not return same version"
+    verify_version("4.0.19","4.0.19", msg, self)
   end
 
   def test_affected_mswin_version_returns_same_version
     set_ruby_platform("mswin")
-    set_vbox_version("4.2.1")
-    def download_iso(url, isofile)
-      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.2.1/"
-      assert(url.include?(expected_url_prefix))
-      assert_equal("VBoxGuestAdditions_4.2.1.iso", isofile)
+    msg = "affected mswin version did not return same version"
+    affected_versions.keys.each do |version|
+      verify_version(version, version, msg, self)
     end
-    download_vbox_guest_additions_iso({})
   end
 
   def test_unaffected_mswin_version_returns_same_version
     set_ruby_platform("mswin")
-    set_vbox_version("4.0.19")
-    def download_iso(url, isofile)
-      expected_url_prefix = "http://download.virtualbox.org/virtualbox/4.0.19/"
-      assert(url.include?(expected_url_prefix))
-      assert_equal("VBoxGuestAdditions_4.0.19.iso", isofile)
-    end
-    download_vbox_guest_additions_iso({})
+    msg = "unaffected mswin version did not return same version"
+    verify_version("4.0.19","4.0.19", msg, self)
   end
 
 private

--- a/test/veewee/provider/virtualbox/box/helper/version.rb
+++ b/test/veewee/provider/virtualbox/box/helper/version.rb
@@ -5,10 +5,19 @@ require 'logger'
 class TestVboxGuestAdditionsHelper < Test::Unit::TestCase
   include Veewee::Provider::Virtualbox::BoxCommand
 
+  def affected_versions
+    {
+      "4.2.1" => "4.2.0",
+      "4.1.23" => "4.1.22"
+    }
+  end
+
   def test_affected_osx_version_returns_downpatched_ga_version
     set_ruby_platform("darwin")
-    set_vbox_version("4.2.1")
-    assert_equal("4.2.0", self.vboxga_version)
+    affected_versions.each do |vbox_version, guest_version|
+      set_vbox_version(vbox_version)
+      assert_equal(guest_version, self.vboxga_version)
+    end
   end
 
   def test_unaffected_osx_version_returns_same_version
@@ -19,8 +28,10 @@ class TestVboxGuestAdditionsHelper < Test::Unit::TestCase
 
   def test_affected_linux_version_returns_same_version
     set_ruby_platform("linux")
-    set_vbox_version("4.2.1")
-    assert_equal("4.2.1", self.vboxga_version)
+    affected_versions.keys.each do |version|
+      set_vbox_version(version)
+      assert_equal(version, self.vboxga_version)
+    end
   end
 
   def test_unaffected_linux_version_returns_same_version
@@ -31,8 +42,10 @@ class TestVboxGuestAdditionsHelper < Test::Unit::TestCase
 
   def test_affected_mswin_version_returns_same_version
     set_ruby_platform("mswin")
-    set_vbox_version("4.2.1")
-    assert_equal("4.2.1", self.vboxga_version)
+    affected_versions.keys.each do |version|
+      set_vbox_version(version)
+      assert_equal(version, self.vboxga_version)
+    end
   end
 
   def test_unaffected_mswin_version_returns_same_version


### PR DESCRIPTION
Follows SHA: 63b018f53b5d and refactors to ease future related updates
