### PR TITLE
 add adaptable template for funtoo x86_64 with rbenv

### DIFF
--- a/templates/funtoo-latest-x86_64/definition.rb
+++ b/templates/funtoo-latest-x86_64/definition.rb
@@ -1,21 +1,12 @@
 password = 'vagrant'
 
 Veewee::Session.declare({
-# READ: http://www.virtualbox.org/manual/ch08.html#vboxmanage - some nice options below...
-# ...disabled for greater compatibility - we shouldn't depend on this
-#  :virtualbox => { :vm_options => [{
-#    'firmware' => 'efi',
-#    'ioapic' => 'on',
-#    'hpet' => 'on',
-#    'pae' => 'on'
-#  }] },
   :hostiocache => 'off',
   :cpu_count => '1',
   :memory_size=> '384',
   :disk_size => '10140',
   :disk_format => 'VDI',
-#  :os_type_id => 'Gentoo',
-  :os_type_id => 'Gentoo_64',
+  :os_type_id => 'Gentoo_64', # for 32bit, change to 'Gentoo'
   :iso_file => "systemrescuecd-x86-3.0.0.iso",
   :iso_src => "http://freefr.dl.sourceforge.net/project/systemrescuecd/sysresccd-x86/3.0.0/systemrescuecd-x86-3.0.0.iso",
   :iso_md5 => "6bb6241af752b1d6dab6ae9e6e3e770e",


### PR DESCRIPTION
This is another template for a 64 bit Funtoo system.
It produces a fully validating Vagrant box, includes the current ruby version 1.9.3-p286 installed under a global rbenv installation and is geared towards extension - a lot of variables are set at the top and it would be easy to derive a 32 bit system or switch from Funtoo to Gentoo.
Building and packaging it results in a box 1GB in size, but including the full Kernel sources and a recent snapshot of the package tree.
I included the build date in the specification as Gentoo and Funtoo use rolling releases, but it's easily adaptable in the top of postinstall.sh.
