### PR TITLE
Add template for Oracle Enterprise Linux 6.3

### DIFF
--- a/templates/OracleLinux-6.3-x86_64-DVD/base.sh
+++ b/templates/OracleLinux-6.3-x86_64-DVD/base.sh
@@ -1,0 +1,30 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+cat > /etc/yum.repos.d/public-yum-ol6.repo << EOM
+[ol6_u3_base]
+name=Oracle Linux $releasever Update 3 installation media copy (\$basearch)
+baseurl=http://public-yum.oracle.com/repo/OracleLinux/OL6/3/base/\$basearch/
+gpgkey=http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol6
+gpgcheck=1
+enabled=1
+
+[ol6_UEK_latest]
+name=Latest Unbreakable Enterprise Kernel for Oracle Linux \$releasever (\$basearch)
+baseurl=http://public-yum.oracle.com/repo/OracleLinux/OL6/UEK/latest/\$basearch/
+gpgkey=http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol6
+gpgcheck=1
+enabled=1
+EOM
+
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=http://download.fedoraproject.org/pub/epel/6/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` kernel-uek-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget
+

--- a/templates/OracleLinux-6.3-x86_64-DVD/chef.sh
+++ b/templates/OracleLinux-6.3-x86_64-DVD/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+gem install --no-ri --no-rdoc chef
+

--- a/templates/OracleLinux-6.3-x86_64-DVD/cleanup.sh
+++ b/templates/OracleLinux-6.3-x86_64-DVD/cleanup.sh
@@ -1,0 +1,5 @@
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
+rm -rf VBoxGuestAdditions_*.iso
+

--- a/templates/OracleLinux-6.3-x86_64-DVD/definition.rb
+++ b/templates/OracleLinux-6.3-x86_64-DVD/definition.rb
@@ -1,0 +1,40 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '480',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'RedHat_64',
+  :iso_file => "OracleLinux-R6-U3-Server-x86_64-dvd.iso",
+  :iso_src => "http://mirrors.wimmekes.net/pub/OracleLinux/OL6/U3/x86_64/OracleLinux-R6-U3-Server-x86_64-dvd.iso",
+  :iso_md5 => "7daae91cc0437f6a98a4359ad9706d678a9f19de",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "veewee",
+  :ssh_password => "veewee",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "ruby.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    #"kvm.sh",
+    #"vmfusion.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/OracleLinux-6.3-x86_64-DVD/ks.cfg
+++ b/templates/OracleLinux-6.3-x86_64-DVD/ks.cfg
@@ -1,0 +1,42 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+
+%post
+/usr/bin/yum -y install sudo
+/usr/sbin/groupadd veewee
+/usr/sbin/useradd veewee -g veewee -G wheel
+echo "veewee"|passwd --stdin veewee
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+%end
+

--- a/templates/OracleLinux-6.3-x86_64-DVD/puppet.sh
+++ b/templates/OracleLinux-6.3-x86_64-DVD/puppet.sh
@@ -1,0 +1,12 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter
+

--- a/templates/OracleLinux-6.3-x86_64-DVD/ruby.sh
+++ b/templates/OracleLinux-6.3-x86_64-DVD/ruby.sh
@@ -1,0 +1,3 @@
+# Install Ruby
+yum -y install ruby ruby-devel rubygems
+

--- a/templates/OracleLinux-6.3-x86_64-DVD/vagrant.sh
+++ b/templates/OracleLinux-6.3-x86_64-DVD/vagrant.sh
@@ -1,0 +1,18 @@
+# Vagrant specific
+date > /etc/vagrant_box_build_time
+
+# Add vagrant user
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Customize the message of the day
+echo 'Welcome to your Vagrant-built virtual machine.' > /etc/motd

--- a/templates/OracleLinux-6.3-x86_64-DVD/virtualbox.sh
+++ b/templates/OracleLinux-6.3-x86_64-DVD/virtualbox.sh
@@ -1,0 +1,8 @@
+# Installing the virtualbox guest additions
+VBOX_VERSION=$(cat /home/veewee/.vbox_version)
+cd /tmp
+mount -o loop /home/veewee/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/veewee/VBoxGuestAdditions_*.iso
+

--- a/templates/OracleLinux-6.3-x86_64-DVD/zerodisk.sh
+++ b/templates/OracleLinux-6.3-x86_64-DVD/zerodisk.sh
@@ -1,0 +1,3 @@
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY


### PR DESCRIPTION
The template is based off of the CentOS 6.3 x86_64 receipe.

Changes:
Added Oracle yum repos
Added the kernel-uek-devel package required for the virtualbox install.
Pointed to the OEL 6.3 ISO
