### PR TITLE
Fix the dhcp clean up for Ubuntu 12.04 or newer's postinstall.sh

### DIFF
--- a/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
@@ -57,7 +57,7 @@ rm -f /EMPTY
 
 # Removing leftover leases and persistent rules
 echo "cleaning up dhcp leases"
-rm /var/lib/dhcp3/*
+rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 # http://6.ptmc.org/?p=164

--- a/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
@@ -78,7 +78,7 @@ rm -f /EMPTY
 
 # Removing leftover leases and persistent rules
 echo "cleaning up dhcp leases"
-rm /var/lib/dhcp3/*
+rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 # http://6.ptmc.org/?p=164

--- a/templates/ubuntu-12.04.1-server-i386-packages/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-i386-packages/postinstall.sh
@@ -57,7 +57,7 @@ rm -f /EMPTY
 
 # Removing leftover leases and persistent rules
 echo "cleaning up dhcp leases"
-rm /var/lib/dhcp3/*
+rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 # http://6.ptmc.org/?p=164

--- a/templates/ubuntu-12.04.1-server-i386/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-i386/postinstall.sh
@@ -78,7 +78,7 @@ rm -f /EMPTY
 
 # Removing leftover leases and persistent rules
 echo "cleaning up dhcp leases"
-rm /var/lib/dhcp3/*
+rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 # http://6.ptmc.org/?p=164

--- a/templates/ubuntu-12.10-server-amd64-packages/postinstall.sh
+++ b/templates/ubuntu-12.10-server-amd64-packages/postinstall.sh
@@ -60,7 +60,7 @@ rm -f /EMPTY
 
 # Removing leftover leases and persistent rules
 echo "cleaning up dhcp leases"
-rm /var/lib/dhcp3/*
+rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 # http://6.ptmc.org/?p=164

--- a/templates/ubuntu-12.10-server-amd64/postinstall.sh
+++ b/templates/ubuntu-12.10-server-amd64/postinstall.sh
@@ -82,7 +82,7 @@ rm -f /EMPTY
 
 # Removing leftover leases and persistent rules
 echo "cleaning up dhcp leases"
-rm /var/lib/dhcp3/*
+rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 # http://6.ptmc.org/?p=164

--- a/templates/ubuntu-12.10-server-i386-packages/postinstall.sh
+++ b/templates/ubuntu-12.10-server-i386-packages/postinstall.sh
@@ -60,7 +60,7 @@ rm -f /EMPTY
 
 # Removing leftover leases and persistent rules
 echo "cleaning up dhcp leases"
-rm /var/lib/dhcp3/*
+rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 # http://6.ptmc.org/?p=164

--- a/templates/ubuntu-12.10-server-i386/postinstall.sh
+++ b/templates/ubuntu-12.10-server-i386/postinstall.sh
@@ -83,7 +83,7 @@ rm -f /EMPTY
 
 # Removing leftover leases and persistent rules
 echo "cleaning up dhcp leases"
-rm /var/lib/dhcp3/*
+rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 # http://6.ptmc.org/?p=164


### PR DESCRIPTION
/var/lib/dhcp3 is not a correct path, should be /var/lib/dhcp

For more info, please see the Launchpad issue at https://bugs.launchpad.net/ubuntu/+source/isc-dhcp/+bug/910108
