### PR TITLE
allow definition name to contain plus

### DIFF
--- a/lib/veewee/provider/virtualbox/box/helper/status.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/status.rb
@@ -16,7 +16,7 @@ module Veewee
         def check? type
           command = COMMANDS[type] % @vboxcmd
           shell_results=shell_exec("#{command}",{:mute => true})
-          status=shell_results.stdout.split(/\n/).grep(/\"#{name.gsub(/\+/,'\\\+')}\"/).size!=0
+          status=shell_results.stdout.split(/\n/).grep(/\"#{Regexp.escape(name)}\"/).size!=0
 
           env.logger.info("Vm #{type}? #{status}")
           return status


### PR DESCRIPTION
here is the log with only the first part of the fix:

``` bash
$ VEEWEE_LOG=STDOUT veewee vbox build openSUSE-12.2-DVD+NET-x86_64
2012-12-09 20:34:00 +0100 -  - [veewee] Command: "VBoxManage list runningvms"
2012-12-09 20:34:00 +0100 -  - [veewee] Output:
2012-12-09 20:34:00 +0100 -  - [veewee] -------
2012-12-09 20:34:00 +0100 -  - [veewee] "openSUSE-12.2-DVD+NET-x86_64" {1dc38e51-1959-4a52-9e63-f40979db6e7e}
2012-12-09 20:34:00 +0100 -  - [veewee] Vm running? false
2012-12-09 20:34:00 +0100 - ui - [veewee] Box is not running
Box is not running
```
