### PR TITLE
Puppet requires a user/group for Ubuntu Server 12.04

### DIFF
--- a/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
@@ -29,6 +29,9 @@ cp /etc/sudoers /etc/sudoers.orig
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 
+# Add puppet user and group
+adduser --system --group --home /var/lib/puppet puppet
+
 # Install NFS client
 apt-get -y install nfs-common
 

--- a/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
@@ -30,6 +30,9 @@ cp /etc/sudoers /etc/sudoers.orig
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 
+# Add puppet user and group
+adduser --system --group --home /var/lib/puppet puppet
+
 # Install NFS client
 apt-get -y install nfs-common
 

--- a/templates/ubuntu-12.04.1-server-i386-packages/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-i386-packages/postinstall.sh
@@ -29,6 +29,9 @@ cp /etc/sudoers /etc/sudoers.orig
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 
+# Add puppet user and group
+adduser --system --group --home /var/lib/puppet puppet
+
 # Install NFS client
 apt-get -y install nfs-common
 

--- a/templates/ubuntu-12.04.1-server-i386/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-i386/postinstall.sh
@@ -30,6 +30,9 @@ cp /etc/sudoers /etc/sudoers.orig
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 
+# Add puppet user and group
+adduser --system --group --home /var/lib/puppet puppet
+
 # Install NFS client
 apt-get -y install nfs-common
 

--- a/templates/ubuntu-12.10-server-amd64-packages/postinstall.sh
+++ b/templates/ubuntu-12.10-server-amd64-packages/postinstall.sh
@@ -29,8 +29,8 @@ cp /etc/sudoers /etc/sudoers.orig
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 
-# Add puppet group
-groupadd -r puppet
+# Add puppet user and group
+adduser --system --group --home /var/lib/puppet puppet
 
 # Install NFS client
 apt-get -y install nfs-common

--- a/templates/ubuntu-12.10-server-amd64/postinstall.sh
+++ b/templates/ubuntu-12.10-server-amd64/postinstall.sh
@@ -29,8 +29,8 @@ cp /etc/sudoers /etc/sudoers.orig
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 
-# Add puppet group
-groupadd -r puppet
+# Add puppet user and group
+adduser --system --group --home /var/lib/puppet puppet
 
 # Install NFS client
 apt-get -y install nfs-common

--- a/templates/ubuntu-12.10-server-i386-packages/postinstall.sh
+++ b/templates/ubuntu-12.10-server-i386-packages/postinstall.sh
@@ -29,8 +29,8 @@ cp /etc/sudoers /etc/sudoers.orig
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 
-# Add puppet group
-groupadd -r puppet
+# Add puppet user and group
+adduser --system --group --home /var/lib/puppet puppet
 
 # Install NFS client
 apt-get -y install nfs-common

--- a/templates/ubuntu-12.10-server-i386/postinstall.sh
+++ b/templates/ubuntu-12.10-server-i386/postinstall.sh
@@ -30,8 +30,8 @@ cp /etc/sudoers /etc/sudoers.orig
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 
-# Add puppet group
-groupadd -r puppet
+# Add puppet user and group
+adduser --system --group --home /var/lib/puppet puppet
 
 # Install NFS client
 apt-get -y install nfs-common


### PR DESCRIPTION
Attempting to apply a puppet manifest locally with 'puppet apply' fails without an existing puppet user and group on Ubuntu Server 12.04. This is confirmed from the Puppet installation docs at http://docs.puppetlabs.com/guides/installation.html#installing-from-gems-not-recommended

Adding a change here to the postinstall scripts for Ubuntu Server 12.04 and 12.10 to create a system user and group (the puppet group is already added at present for 12.10).
