### PR TITLE
Move sudoers entry to sudoers.d.

### DIFF
--- a/templates/Debian-7.0-b4-amd64-netboot/base.sh
+++ b/templates/Debian-7.0-b4-amd64-netboot/base.sh
@@ -6,8 +6,7 @@ apt-get -y install curl unzip
 apt-get clean
 
 # Set up sudo
-cp /etc/sudoers /etc/sudoers.orig
-sed -i -e 's/%sudo[ \t]*ALL=(ALL:ALL) ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+echo 'vagrant ALL=NOPASSWD:ALL' > /etc/sudoers.d/vagrant
 
 # Tweak sshd to prevent DNS resolution (speed up logins)
 echo 'UseDNS no' >> /etc/ssh/sshd_config

--- a/templates/Debian-7.0-b4-i386-netboot/base.sh
+++ b/templates/Debian-7.0-b4-i386-netboot/base.sh
@@ -6,8 +6,7 @@ apt-get -y install curl unzip
 apt-get clean
 
 # Set up sudo
-cp /etc/sudoers /etc/sudoers.orig
-sed -i -e 's/%sudo\s+ALL=(ALL:ALL) ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+echo 'vagrant ALL=NOPASSWD:ALL' > /etc/sudoers.d/vagrant
 
 # Tweak sshd to prevent DNS resolution (speed up logins)
 echo 'UseDNS no' >> /etc/ssh/sshd_config


### PR DESCRIPTION
Currently, the sudo setup fails, and 'vagrant' is always asked for a password. This break normal usage in Vagrant.
