### PR TITLE
Add vagrant user to sudo group instead of admin.

### DIFF
--- a/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
@@ -21,13 +21,12 @@ sh /mnt/VBoxLinuxAdditions.run
 umount /mnt
 
 rm VBoxGuestAdditions_$VBOX_VERSION.iso
+rm /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso
 
-# Setup sudo to allow no-password sudo for "admin"
-groupadd -r admin
-usermod -a -G admin vagrant
+# Setup sudo to allow no-password sudo for "sudo"
+usermod -a -G sudo vagrant
 cp /etc/sudoers /etc/sudoers.orig
-sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
-sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
+sed -i -e 's/%sudo   ALL=(ALL:ALL) ALL/%sudo   ALL=(ALL:ALL) NOPASSWD: ALL/' /etc/sudoers
 
 # Add puppet user and group
 adduser --system --group --home /var/lib/puppet puppet

--- a/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
@@ -22,13 +22,12 @@ sh /mnt/VBoxLinuxAdditions.run
 umount /mnt
 
 rm VBoxGuestAdditions_$VBOX_VERSION.iso
+rm /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso
 
-# Setup sudo to allow no-password sudo for "admin"
-groupadd -r admin
-usermod -a -G admin vagrant
+# Setup sudo to allow no-password sudo for "sudo"
+usermod -a -G sudo vagrant
 cp /etc/sudoers /etc/sudoers.orig
-sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
-sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
+sed -i -e 's/%sudo   ALL=(ALL:ALL) ALL/%sudo   ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
 # Add puppet user and group
 adduser --system --group --home /var/lib/puppet puppet


### PR DESCRIPTION
The base distro has replaced the admin group with sudo in the standard
/etc/groups file.

The admin group need not be created if the vagrant user is added to
sudo group instead and /etc/sudoers is edited so that members of sudo
don't require a password.
