### PR TITLE
Fixing the /etc/sudoers NOPASSWORD sed line.

### DIFF
--- a/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
@@ -26,7 +26,7 @@ rm /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso
 # Setup sudo to allow no-password sudo for "sudo"
 usermod -a -G sudo vagrant
 cp /etc/sudoers /etc/sudoers.orig
-sed -i -e 's/%sudo   ALL=(ALL:ALL) ALL/%sudo   ALL=(ALL:ALL) NOPASSWD: ALL/' /etc/sudoers
+sed -ri -e 's/(%sudo\s+ALL=\(ALL:ALL\))\s+ALL/\1 NOPASSWD: ALL/' /etc/sudoers
 
 # Add puppet user and group
 adduser --system --group --home /var/lib/puppet puppet

--- a/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
@@ -27,7 +27,7 @@ rm /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso
 # Setup sudo to allow no-password sudo for "sudo"
 usermod -a -G sudo vagrant
 cp /etc/sudoers /etc/sudoers.orig
-sed -i -e 's/%sudo   ALL=(ALL:ALL) ALL/%sudo   ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
+sed -ri -e 's/(%sudo\s+ALL=\(ALL:ALL\))\s+ALL/\1 NOPASSWD: ALL/' /etc/sudoers
 
 # Add puppet user and group
 adduser --system --group --home /var/lib/puppet puppet


### PR DESCRIPTION
The sed line to modify /etc/sudoers for NOPASSWORD was not matching the white space
exactly which caused the modification to fail.  I changed the sed line to use \s+
instead of spaces so it would work with any number of white space there.
