### PR TITLE
Use thread when typing boot sequence

### DIFF
--- a/lib/veewee/provider/core/box/build.rb
+++ b/lib/veewee/provider/core/box/build.rb
@@ -66,7 +66,7 @@ module Veewee
           })
 
           # Type the boot sequence
-          self.console_type(boot_sequence)
+          Thread.new { self.console_type(boot_sequence) }
 
           self.handle_kickstart(options)
 


### PR DESCRIPTION
In some cases the delay in finishing the console_type method takes longer than the boot process of the OS within the virtual machine. In these cases the kickstart server will only be started after the VM searches for it, which usually results in an error.

Putting the console_type method into a thread solves this problem, as it ensures that the kickstart server starts to wait for connections before the typing is finished.

The issue has been observed with the KVM provider, but may also occur for other providers. The fix will work for all providers and does not change the current behavior.
