### PR TITLE
Correctly modify /etc/sudeors to allow passwordsless sudo.

### DIFF
--- a/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64-packages/postinstall.sh
@@ -26,7 +26,7 @@ rm /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso
 # Setup sudo to allow no-password sudo for "sudo"
 usermod -a -G sudo vagrant
 cp /etc/sudoers /etc/sudoers.orig
-sed -i -e 's/%sudo   ALL=(ALL:ALL) ALL/%sudo   ALL=(ALL:ALL) NOPASSWD: ALL/' /etc/sudoers
+sed -i -e 's/%sudo\tALL=(ALL:ALL) ALL/%sudo\tALL=(ALL:ALL) NOPASSWD: ALL/' /etc/sudoers
 
 # Add puppet user and group
 adduser --system --group --home /var/lib/puppet puppet

--- a/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
+++ b/templates/ubuntu-12.04.1-server-amd64/postinstall.sh
@@ -27,7 +27,7 @@ rm /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso
 # Setup sudo to allow no-password sudo for "sudo"
 usermod -a -G sudo vagrant
 cp /etc/sudoers /etc/sudoers.orig
-sed -i -e 's/%sudo   ALL=(ALL:ALL) ALL/%sudo   ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
+sed -i -e 's/%sudo\tALL=(ALL:ALL) ALL/%sudo\tALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
 # Add puppet user and group
 adduser --system --group --home /var/lib/puppet puppet


### PR DESCRIPTION
The sed expression in the previous postinstall.sh file modifications
I had made used 4 spaces instead of a single '\t' which prevented
the required substition in the /etc/sudoers file which prevented the
vagrant user from being able to sudo without provide a password. The
sed expression now correctly substitutes the directives for the
sudo group so passwordless sudo is enabled.
