### PR TITLE
Trap IOErrors as a normal condition.

### DIFF
--- a/lib/veewee/provider/core/helper/ssh.rb
+++ b/lib/veewee/provider/core/helper/ssh.rb
@@ -47,6 +47,9 @@ module Veewee
                   end
                 end
               end
+            rescue IOError
+              ui.info "Received a disconnect; moving on"
+              sleep 5
             rescue Timeout::Error
               raise Veewee::Error, "Ssh timeout #{timeout} sec has been reached."
             end


### PR DESCRIPTION
As discussed, Net::SSH will throw this if the connection is terminated by the remote host; in Veewee, this is used to chain together multiple postinstall scripts with reboots between them.
See this thread for more information: https://groups.google.com/d/topic/veewee/oacb_ko1pT0/discussion
