### PR TITLE
[KVM] Add support for alternate disk formats

### DIFF
--- a/lib/veewee/provider/kvm/box.rb
+++ b/lib/veewee/provider/kvm/box.rb
@@ -33,6 +33,12 @@ module Veewee
 
           @connection=::Fog::Compute[:libvirt]
 
+          # Many of the existing templates have disk_format set to "VDI"
+          # Use "raw" instead as a Libvirt-compatible default
+          definition.disk_format.downcase!
+          definition.disk_format = "raw" if definition.disk_format == "vdi"
+          @volume_name = "#{name}.#{definition.disk_format}"
+
         end
 
       end # End Class

--- a/lib/veewee/provider/kvm/box/create.rb
+++ b/lib/veewee/provider/kvm/box/create.rb
@@ -46,6 +46,7 @@ module Veewee
               :arch => definition.os_type_id.end_with?("_64") ? "x86_64" : "i686",
               :iso_dir => env.config.veewee.iso_dir,
               :volume_pool_name => volume_pool_name,
+              :volume_format_type => definition.disk_format,
               :network_nat_network => network_name
           }
 

--- a/lib/veewee/provider/kvm/box/destroy.rb
+++ b/lib/veewee/provider/kvm/box/destroy.rb
@@ -4,7 +4,7 @@ module Veewee
       module BoxCommand
         # Destroy a vm
         def destroy(options={})
-          if @connection.servers.all(:name => name).nil?
+          unless exists_vm? or exists_volume?
             env.ui.error "Error:: You tried to destroy a non-existing box '#{name}'"
             raise Veewee::Error,"Error:: You tried to destroy a non-existing box '#{name}'"
           end
@@ -12,9 +12,9 @@ module Veewee
           self.poweroff if running?
           destroy_vm if exists_vm?
 
-          vol_exists=!@connection.volumes.all(:name => "#{name}.img").nil?
-          env.logger.info "Volume exists? : #{vol_exists}"
-          destroy_volume if exists_volume?
+          vol_exists = exists_volume?
+          env.logger.info "Volume exists?: #{vol_exists}"
+          destroy_volume if vol_exists
         end
 
         def destroy_vm
@@ -23,8 +23,7 @@ module Veewee
         end
 
         def destroy_volume
-          vol=@connection.volumes.all(:name => "#{name}.img").first
-          vol.destroy
+          @connection.volumes.all(:name => @volume_name).first.destroy
         end
       end # End Module
 

--- a/lib/veewee/provider/kvm/box/helper/status.rb
+++ b/lib/veewee/provider/kvm/box/helper/status.rb
@@ -15,11 +15,15 @@ module Veewee
         end
 
         def exists_volume?
-          @connection.list_volumes.find { |v| v[:name] == "#{name}.img" }
+          !@connection.list_volumes(:name => @volume_name).first.empty?
         end
 
         def exists_vm?
-          @connection.list_domains.find { |d| d[:name] == name }
+          begin
+            @connection.list_domains(:name => name)
+          rescue Libvirt::RetrieveError
+            false
+          end
         end
 
       end # End Module


### PR DESCRIPTION
Allows the user to define a Libvirt-supported disk_format (e.g. qcow2, raw, vmdk) in the definition.rb. Existing templates that use the VDI disk_format will instead be treated as 'raw'.
