### PR TITLE
Fix Debian-7.0-b4-amd64-netboot os_type_id

### DIFF
--- a/templates/Debian-7.0-b4-amd64-netboot/definition.rb
+++ b/templates/Debian-7.0-b4-amd64-netboot/definition.rb
@@ -4,7 +4,7 @@ Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
-  :os_type_id => 'Debian',
+  :os_type_id => 'Debian_64',
   :iso_file => "debian-wheezy-DI-b4-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/cdimage/wheezy_di_beta4/amd64/iso-cd/debian-wheezy-DI-b4-amd64-netinst.iso",
   :iso_md5 => "9fcd2bb541f9b6b32f2a17116d606bed",


### PR DESCRIPTION
The Debian Wheezy (7.0-b4) os_type_id for amd64-netboot is incorrectly
set to 'Debian'. It should be 'Debian_64' to allow boot.
