### PR TITLE
Errors on vmware fusion 4.1.4 if set to RedHat_64 should be rhel6-64

### DIFF
--- a/lib/veewee/config/ostypes.yml
+++ b/lib/veewee/config/ostypes.yml
@@ -185,7 +185,7 @@ RedHat:
   :vbox: RedHat
   :parallels: redhat
 RedHat_64:
-  :fusion: RedHat_64
+  :fusion: rhel6-64
   :kvm:
   :vbox: RedHat_64
   :parallels: redhat


### PR DESCRIPTION
Errors using fusion 4.1.4 should be rhel6-64 not RedHat_64
