### PR TITLE
Honor validation_dir in subcommand validate

### DIFF
--- a/lib/veewee/provider/core/box/validate_tags.rb
+++ b/lib/veewee/provider/core/box/validate_tags.rb
@@ -37,7 +37,7 @@ module Veewee
             featurefile="veewee.feature"
           end
 
-          feature_path=File.join(File.dirname(__FILE__),"..","..","..","..","..","validation",featurefile)
+          feature_path=File.join(definition.env.validation_dir,featurefile)
 
           features=Array.new
           features[0]=feature_path


### PR DESCRIPTION
Hi jedi4ever

In order to implement a ci workflow with additional cucumber features I changed the veewee.validation_dir in Veeweefile but the subcommand validate does not honored this configuration.

Since I am no ruby coder please  put me in the right direction if I am completely wrong.
