### PR TITLE
Adds an install of dkms to virtualbox.sh for the Debian-6.0.6-amd64-netb...

### DIFF
--- a/templates/Debian-6.0.6-amd64-netboot/virtualbox.sh
+++ b/templates/Debian-6.0.6-amd64-netboot/virtualbox.sh
@@ -3,6 +3,7 @@ if test -f .vbox_version ; then
   /etc/init.d/virtualbox-ose-guest-utils stop
   rmmod vboxguest
   aptitude -y purge virtualbox-ose-guest-x11 virtualbox-ose-guest-dkms virtualbox-ose-guest-utils
+  aptitude -y install dkms
 
   # Install the VirtualBox guest additions
   VBOX_VERSION=$(cat /home/vagrant/.vbox_version)


### PR DESCRIPTION
The cucumber test was failing when I was buliding basebox's with the Debian-6.0.6-amd64-netboot template.  It needs dkms to install properly.  I added this inside the virtualbox shell script that gets run.  After doing this the cucumber test passed fine.
