### PR TITLE
Fix PATH issue in sudoers file for CentOS-5.5-x86_64-netboot

### DIFF
--- a/templates/CentOS-5.5-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-5.5-x86_64-netboot/postinstall.sh
@@ -54,6 +54,7 @@ rm VBoxGuestAdditions_$VBOX_VERSION.iso
 
 
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
 
 #poweroff -h
 


### PR DESCRIPTION
Added sed command to postinstall.sh to include PATH in the env_keep
block in /etc/sudoers. Makes it so vagrant is able to detect chef and
puppet on the VM.
