### PR TITLE
vewee hangs waiting for user selection of keyboard type. Add keyboard selection config, in line with the Debian-wheezy-amd64 template

### DIFF
--- a/templates/Debian-7.0-b4-i386-netboot/definition.rb
+++ b/templates/Debian-7.0-b4-i386-netboot/definition.rb
@@ -23,6 +23,7 @@ Veewee::Definition.declare({
      'debconf/frontend=noninteractive ',
      'console-setup/ask_detect=false ',
      'console-keymaps-at/keymap=us ',
+     'keyboard-configuration/xkb-keymap=us ',
      '<Enter>'
   ],
   :kickstart_port => "7122",


### PR DESCRIPTION
vewee hangs waiting for user selection of keyboard type
