### PR TITLE
Preserve permissions when copying a new definition from template

### DIFF
--- a/lib/veewee/definitions.rb
+++ b/lib/veewee/definitions.rb
@@ -107,7 +107,7 @@ module Veewee
       else
         begin
           env.logger.debug("Starting copy '#{template.path}' to '#{dst_dir}'")
-          FileUtils.cp_r(template.path + "/.", dst_dir)
+          FileUtils.cp_r(template.path + "/.", dst_dir, :preserve => true)
           env.logger.debug("Copy '#{template.path}' to '#{dst_dir}' succesful")
         rescue Exception => ex
           env.logger.fatal("Copy '#{template.path}' to #{dst_dir}' failed: #{ex}")


### PR DESCRIPTION
In most cases permissions shouldn't matter, but in the case of #481 we also copy over a shell script to be executed to prepare the ISO, so it would be useful if its executability is preserved.
