### PR TITLE
new Debian 7.0 rc1 template

### DIFF
--- a/templates/Debian-7.0-rc1-amd64-netboot/base.sh
+++ b/templates/Debian-7.0-rc1-amd64-netboot/base.sh
@@ -3,6 +3,7 @@ apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev
 apt-get -y install curl unzip
+apt-get -y install --no-install-recommends libdbus-1-3
 apt-get clean
 
 # Set up sudo

--- a/templates/Debian-7.0-rc1-amd64-netboot/definition.rb
+++ b/templates/Debian-7.0-rc1-amd64-netboot/definition.rb
@@ -4,7 +4,7 @@ Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
-  :os_type_id => 'Debian',
+  :os_type_id => 'Debian_64',
   :iso_file => "debian-wheezy-DI-rc1-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/cdimage/wheezy_di_rc1/amd64/iso-cd/debian-wheezy-DI-rc1-amd64-netinst.iso",
   :iso_md5 => "412f77d4b98adf2a7d575745fd282d78",


### PR DESCRIPTION
I've fixed up the problems with the Debian 7.0 rc1 template.  The shared folders weren't being mounted properly because the libdbus-1-3 package wasn't being installed.  

I think this fix can also help issue #459.
