### PR TITLE
Allow directory names to contain spaces

### DIFF
--- a/lib/veewee/provider/core/box/floppy.rb
+++ b/lib/veewee/provider/core/box/floppy.rb
@@ -21,7 +21,7 @@ module Veewee
               env.logger.info "Removing previous floppy file"
               FileUtils.rm(floppy_file)
             end
-            command="java -jar #{javacode_dir}/dir2floppy.jar \"#{temp_dir}\" \"#{floppy_file}\""
+            command="java -jar \"#{javacode_dir}/dir2floppy.jar\" \"#{temp_dir}\" \"#{floppy_file}\""
             shell_exec("#{command}")
           end
         end

--- a/lib/veewee/provider/virtualbox/box/export_vagrant.rb
+++ b/lib/veewee/provider/virtualbox/box/export_vagrant.rb
@@ -116,7 +116,7 @@ module Veewee
 
             ui.info "Packaging the box"
             FileUtils.cd(tmp_dir)
-            command = "tar -cvf #{box_path} ."
+            command = "tar -cvf '#{box_path}' ."
             env.logger.debug(command)
             shell_exec (command)
 


### PR DESCRIPTION
Building boxes when the VM was contained in a directory with spaces failed.
