### PR TITLE
Fix VBoxManage --version on Windows

### DIFF
--- a/lib/veewee/provider/virtualbox/box/helper/version.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/version.rb
@@ -9,7 +9,8 @@ module Veewee
         def vbox_version
           command="#{@vboxcmd} --version"
           stderr = "/dev/null"
-          stderr = "nul" if definition.os_type_id=~/^Win/
+          is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
+          stderr = "nul" if is_windows
           shell_results=shell_exec("#{command}",{:mute => true, :stderr => stderr})
           version=shell_results.stdout.strip.split(/[^0-9\.]/)[0]
           return version


### PR DESCRIPTION
 - VBoxManage --version is not executed on the VM
 - redirecting to /dev/null on Windows fails
