### PR TITLE
Added Windows tar support to Vagrant export

### DIFF
--- a/lib/veewee/provider/virtualbox/box/export_vagrant.rb
+++ b/lib/veewee/provider/virtualbox/box/export_vagrant.rb
@@ -115,8 +115,12 @@ module Veewee
             shell_exec(command, {:mute => false})
 
             ui.info "Packaging the box"
-            FileUtils.cd(tmp_dir)
-            command = "tar -cvf '#{box_path}' ."
+            command_box_path = box_path
+            is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
+            if is_windows
+              command_box_path = command_box_path.gsub(/^([A-Z])\:\/(.*)$/, '/\1/\2')
+            end
+            command = "tar -cvf '#{command_box_path}' ."
             env.logger.debug(command)
             shell_exec (command)
 


### PR DESCRIPTION
 - Windows tar seems to only be happy with fully qualified paths
   in a *nix style, so instead of C:\Folder\Two or C:/Folder/Two
   it wants /C/Folder/Two
 - Tested against Tar 1.2.2 on Windows
