### PR TITLE
Remove CYGWIN=tty for Windows 7 SP1

### DIFF
--- a/templates/windows-7sp1-ultimate-amd64/install-cygwin-sshd.bat
+++ b/templates/windows-7sp1-ultimate-amd64/install-cygwin-sshd.bat
@@ -22,7 +22,7 @@ cmd /c %SystemDrive%\cygwin\bin\bash -c 'PATH=/usr/local/bin:/usr/bin:/bin:/usr/
 
 %SystemDrive%\cygwin\usr\bin\sleep 1
 
-%SystemDrive%\cygwin\bin\bash -c 'PATH=/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin /usr/bin/ssh-host-config -y -c "ntsecbinmode tty" -w "abc&&123!!" '
+%SystemDrive%\cygwin\bin\bash -c 'PATH=/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin /usr/bin/ssh-host-config -y -c "ntsecbinmode" -w "abc&&123!!" '
 
 %SystemDrive%\cygwin\usr\bin\sleep 2 
 


### PR DESCRIPTION
This fixes #422. I believe the cause of the issue is that cygwin changed so that it no longer supported `CYGWIN=tty`.

Whenever I would ssh into the machine, it would complain about `CYGWIN=tty` no longer being supported. This change makes the message go away.

Presumably the same change needs to be run on all the Windows 7 definitions, but I've only tested it with this one.
