### PR TITLE
vagrant basebox export doesn't work by default

### DIFF
--- a/lib/veewee/provider/virtualbox/box/export_vagrant.rb
+++ b/lib/veewee/provider/virtualbox/box/export_vagrant.rb
@@ -115,6 +115,7 @@ module Veewee
             shell_exec(command, {:mute => false})
 
             ui.info "Packaging the box"
+            FileUtils.cd(tmp_dir)
             command_box_path = box_path
             is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
             if is_windows


### PR DESCRIPTION
With the default config, veewee ends up trying to tar up the current directory, but never changes directory to the temp_dir that the box is exported to.

This patch simply changes dir appropriately before running tar. No other changes are necessary for successful exports.
