### PR TITLE
prevent Address already in use error for multiple starts on same port

### DIFF
--- a/lib/veewee/provider/core/helper/web.rb
+++ b/lib/veewee/provider/core/helper/web.rb
@@ -47,7 +47,7 @@ module Veewee
           end
 
           def allow_for_http_request(filename,options) # start in new thread
-            s = server_for_http_request(filename,options.merge({:threaded => true}))
+            s = server_for_http_request(filename,options.merge({:threaded => false}))
             Thread.new { s.start }
           end
 


### PR DESCRIPTION
It seems as though 8cd4566e23782f402cc4cb59e59160bcb5dd3e47 broke something when introducing threading causing the Webrick server to instantiate multiple times on the same port.  Probably more a work around than a fix, better solutions appreciated.
