### PR TITLE
Fix password-less login on ubuntu-12.04.2-server-amd64

### DIFF
--- a/templates/ubuntu-12.04.2-server-amd64/postinstall.sh
+++ b/templates/ubuntu-12.04.2-server-amd64/postinstall.sh
@@ -27,7 +27,7 @@ rm /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso
 # Setup sudo to allow no-password sudo for "sudo"
 usermod -a -G sudo vagrant
 cp /etc/sudoers /etc/sudoers.orig
-sed -i -e 's/%sudo\tALL=(ALL:ALL) ALL/%sudo\tALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
+sed -i -e 's/%sudo	ALL=(ALL:ALL) ALL/%sudo\tALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
 # Add puppet user and group
 adduser --system --group --home /var/lib/puppet puppet


### PR DESCRIPTION
Password-less ssh for the vagrant user didn't work for me in ubuntu-12.04.2-server-amd64. I had to update the postinstall.sh to use a literal tab character in the sed regular expression in place of the "\t" character to get it to work.
