### PR TITLE
Add CentOS 6.4 minimal templates

### DIFF
--- a/templates/CentOS-6.4-i386-minimal/base.sh
+++ b/templates/CentOS-6.4-i386-minimal/base.sh
@@ -1,0 +1,14 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=http://download.fedoraproject.org/pub/epel/6/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms nfs-utils
+

--- a/templates/CentOS-6.4-i386-minimal/chef.sh
+++ b/templates/CentOS-6.4-i386-minimal/chef.sh
@@ -1,0 +1,2 @@
+# Install Chef
+curl -L https://www.opscode.com/chef/install.sh | bash

--- a/templates/CentOS-6.4-i386-minimal/cleanup.sh
+++ b/templates/CentOS-6.4-i386-minimal/cleanup.sh
@@ -1,0 +1,5 @@
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
+rm -rf VBoxGuestAdditions_*.iso
+

--- a/templates/CentOS-6.4-i386-minimal/definition.rb
+++ b/templates/CentOS-6.4-i386-minimal/definition.rb
@@ -1,0 +1,37 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '480',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'RedHat',
+  :iso_file => "CentOS-6.4-i386-minimal.iso",
+  :iso_src => "http://yum.singlehop.com/CentOS/6.4/isos/i386/CentOS-6.4-i386-minimal.iso",
+  :iso_md5 => "6b5c727fa76fcce7c9ab6213ad3df75a",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "veewee",
+  :ssh_password => "veewee",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/CentOS-6.4-i386-minimal/ks.cfg
+++ b/templates/CentOS-6.4-i386-minimal/ks.cfg
@@ -1,0 +1,36 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --nobase
+@core
+%end
+
+%post
+/usr/bin/yum -y install sudo
+/usr/sbin/groupadd veewee
+/usr/sbin/useradd veewee -g veewee -G wheel
+echo "veewee"|passwd --stdin veewee
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+%end
+

--- a/templates/CentOS-6.4-i386-minimal/puppet.sh
+++ b/templates/CentOS-6.4-i386-minimal/puppet.sh
@@ -1,0 +1,12 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter
+

--- a/templates/CentOS-6.4-i386-minimal/vagrant.sh
+++ b/templates/CentOS-6.4-i386-minimal/vagrant.sh
@@ -1,0 +1,18 @@
+# Vagrant specific
+date > /etc/vagrant_box_build_time
+
+# Add vagrant user
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Customize the message of the day
+echo 'Welcome to your Vagrant-built virtual machine.' > /etc/motd

--- a/templates/CentOS-6.4-i386-minimal/virtualbox.sh
+++ b/templates/CentOS-6.4-i386-minimal/virtualbox.sh
@@ -1,0 +1,8 @@
+# Installing the virtualbox guest additions
+VBOX_VERSION=$(cat /home/veewee/.vbox_version)
+cd /tmp
+mount -o loop /home/veewee/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/veewee/VBoxGuestAdditions_*.iso
+

--- a/templates/CentOS-6.4-i386-minimal/zerodisk.sh
+++ b/templates/CentOS-6.4-i386-minimal/zerodisk.sh
@@ -1,0 +1,3 @@
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/templates/CentOS-6.4-x86_64-minimal/base.sh
+++ b/templates/CentOS-6.4-x86_64-minimal/base.sh
@@ -1,0 +1,14 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=http://download.fedoraproject.org/pub/epel/6/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms nfs-utils
+

--- a/templates/CentOS-6.4-x86_64-minimal/chef.sh
+++ b/templates/CentOS-6.4-x86_64-minimal/chef.sh
@@ -1,0 +1,2 @@
+# Install Chef
+curl -L https://www.opscode.com/chef/install.sh | bash

--- a/templates/CentOS-6.4-x86_64-minimal/cleanup.sh
+++ b/templates/CentOS-6.4-x86_64-minimal/cleanup.sh
@@ -1,0 +1,5 @@
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
+rm -rf VBoxGuestAdditions_*.iso
+

--- a/templates/CentOS-6.4-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.4-x86_64-minimal/definition.rb
@@ -1,0 +1,37 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '480',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'RedHat_64',
+  :iso_file => "CentOS-6.4-x86_64-minimal.iso",
+  :iso_src => "http://yum.singlehop.com/CentOS/6.4/isos/x86_64/CentOS-6.4-x86_64-minimal.iso",
+  :iso_md5 => "4a5fa01c81cc300f4729136e28ebe600",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "veewee",
+  :ssh_password => "veewee",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/CentOS-6.4-x86_64-minimal/ks.cfg
+++ b/templates/CentOS-6.4-x86_64-minimal/ks.cfg
@@ -1,0 +1,36 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --nobase
+@core
+%end
+
+%post
+/usr/bin/yum -y install sudo
+/usr/sbin/groupadd veewee
+/usr/sbin/useradd veewee -g veewee -G wheel
+echo "veewee"|passwd --stdin veewee
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+%end
+

--- a/templates/CentOS-6.4-x86_64-minimal/puppet.sh
+++ b/templates/CentOS-6.4-x86_64-minimal/puppet.sh
@@ -1,0 +1,12 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter
+

--- a/templates/CentOS-6.4-x86_64-minimal/vagrant.sh
+++ b/templates/CentOS-6.4-x86_64-minimal/vagrant.sh
@@ -1,0 +1,18 @@
+# Vagrant specific
+date > /etc/vagrant_box_build_time
+
+# Add vagrant user
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Customize the message of the day
+echo 'Welcome to your Vagrant-built virtual machine.' > /etc/motd

--- a/templates/CentOS-6.4-x86_64-minimal/virtualbox.sh
+++ b/templates/CentOS-6.4-x86_64-minimal/virtualbox.sh
@@ -1,0 +1,8 @@
+# Installing the virtualbox guest additions
+VBOX_VERSION=$(cat /home/veewee/.vbox_version)
+cd /tmp
+mount -o loop /home/veewee/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/veewee/VBoxGuestAdditions_*.iso
+

--- a/templates/CentOS-6.4-x86_64-minimal/zerodisk.sh
+++ b/templates/CentOS-6.4-x86_64-minimal/zerodisk.sh
@@ -1,0 +1,3 @@
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY


### PR DESCRIPTION
Based on the 6.3 x64_86 minimal template with a couple minor changes:
- Install chef via the new omnibus installer (so the ruby definitions
  are no longer explicitly needed).
- Update the ks.cfg "%packages" to match the defaults from a standard
  CentOS 6.4 minimal install.
