### PR TITLE
For amd64 Debian 7.0 rc1 template, fix console keymap as 'us'

### DIFF
--- a/templates/Debian-7.0-rc1-amd64-netboot/definition.rb
+++ b/templates/Debian-7.0-rc1-amd64-netboot/definition.rb
@@ -22,6 +22,7 @@ Veewee::Definition.declare({
      'fb=false ',
      'debconf/frontend=noninteractive ',
      'console-setup/ask_detect=false ',
+     'console-keymaps-at/keymap=us ',
      'keyboard-configuration/xkb-keymap=us ',
      '<Enter>'
   ],


### PR DESCRIPTION
Same logic as in the i386 template to use the 'us' console keymap.
Signed-off-by: Rohit Yadav bhaisaab@apache.org
