### PR TITLE
Fixed Debian netboot disc location

### DIFF
--- a/templates/Debian-6.0.6-amd64-netboot/definition.rb
+++ b/templates/Debian-6.0.6-amd64-netboot/definition.rb
@@ -4,7 +4,7 @@ Veewee::Definition.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-6.0.6-amd64-netinst.iso",
-  :iso_src => "http://cdimage.debian.org/debian-cd/6.0.6/amd64/iso-cd/debian-6.0.6-amd64-netinst.iso",
+  :iso_src => "http://cdimage.debian.org/mirror/cdimage/archive/6.0.6/amd64/iso-cd/debian-6.0.6-amd64-netinst.iso",
   :iso_md5 => "00585d63f8a560a73540bd718263319a",
   :iso_download_timeout => "1000",
   :boot_wait => "10", :boot_cmd_sequence => [


### PR DESCRIPTION
6.0.6 has moved into the Debian archive.  This pull req fixes the location of the upstream ISO.
