### PR TITLE
Update to vmfusion ip.rb helper to retrieve IPs for bridged networks in addition to NAT and host-only

### DIFF
--- a/lib/veewee/provider/vmfusion/box/helper/ip.rb
+++ b/lib/veewee/provider/vmfusion/box/helper/ip.rb
@@ -27,7 +27,7 @@ module Veewee
           # Use alternate method to retrieve the IP address using vmrun readVariable
           
           ip_address = shell_exec("vmrun readVariable \"#{vmx_file_path}\" guestVar ip", { :mute => true})
-          return ip_address.stdout
+          return ip_address.stdout.strip
         
           # unless mac_address.nil?
           #   lease = Fission::Lease.find_by_mac_address(mac_address).data


### PR DESCRIPTION
The current code can only retrieve NAT or host-only IPs by polling nat/dhcp settings. This means that a box that is configured for bridged networking isn't accessible with the "veewee fusion ssh <boxname>" command. By using vmrun's guestVar command instead it's possible to retrieve IPs in all networking setups.

I have successfully tested with OS X and CentOS 6.3 guests so far.

Note: this is probably woefully dirty code but it does the job for now. Feel free to clean it up as needed.
