### PR TITLE
Fix regressions in the fusion provider introduced by veewee#596.

### DIFF
--- a/lib/veewee/provider/vmfusion/box/helper/ip.rb
+++ b/lib/veewee/provider/vmfusion/box/helper/ip.rb
@@ -26,17 +26,17 @@ module Veewee
           
           # Use alternate method to retrieve the IP address using vmrun readVariable
           
-          ip_address = shell_exec("vmrun readVariable \"#{vmx_file_path}\" guestVar ip", { :mute => true})
-          return ip_address.stdout.strip
+          ip_address = shell_exec("#{vmrun_cmd.shellescape} readVariable \"#{vmx_file_path}\" guestVar ip", { :mute => true}).stdout.strip
+          return ip_address unless ip_address.empty?
         
-          # unless mac_address.nil?
-          #   lease = Fission::Lease.find_by_mac_address(mac_address).data
-          #   return lease.ip_address unless lease.nil?
-          #   return nil
-          # else
-          #     # No mac address was found for this machine so we can't calculate the ip-address
-          #     return nil
-          #   end
+          unless mac_address.nil?
+            lease = Fission::Lease.find_by_mac_address(mac_address).data
+            return lease.ip_address unless lease.nil?
+            return nil
+          else
+            # No mac address was found for this machine so we can't calculate the ip-address
+            return nil
+          end
         end
 
         # http://www.thirdbit.net/articles/2008/03/04/dhcp-on-vmware-fusion/


### PR DESCRIPTION
I stumbled across two problems with the recent change to the ip address detection for vmware fusion in 2e4a50f611cac93d16079c24ad8fd63fd967ee36:
1. `vmrun` was called without the full path which doesn't work without modifying the PATH variable
2. As briefly mentioned in the pull request the change broke the `fusion build` command because the new method doesn't work at that stage.

As also already suggested in the pull request by @jedi4ever I tried to fix 2. by chaining the different methods of ip adress detection.
