### PR TITLE
Add missing quotes for virtualHW.version in .vmx erb

### DIFF
--- a/lib/veewee/provider/vmfusion/box/template.vmx.erb
+++ b/lib/veewee/provider/vmfusion/box/template.vmx.erb
@@ -16,7 +16,7 @@ ide1:0.present = "TRUE"
 ide1:0.fileName = "<%= iso_file %>"
 ide1:0.deviceType = "cdrom-image"
 <% end %>
-virtualHW.version = <%= virtualhw_version %>
+virtualHW.version = "<%= virtualhw_version %>"
 numvcpus = "<%= cpu_count %>"
 scsi0.present = "TRUE"
 scsi0.virtualDev = "<%= controller_type %>"


### PR DESCRIPTION
In experimenting with the new Vagrant Fusion provider, I've seen a case where when taking a .vmwarevm box built with the vmfusion provider directly into Vagrant (using the Vagrant Fusion provider plugin) triggers a prompt to upgrade the VM version, due to it not parsing the virtualHW.version vmx parameter, as it was missing quotes.

It's possible this has already been (or will be) addressed with updates to the Fusion plugin, but either way the quotes should be there. Didn't see any other params missing quotes either.
