### PR TITLE
cygwin and ssh issues with the windows-2008R2-serverstandard-amd64 template

### DIFF
--- a/templates/windows-2008R2-serverstandard-amd64/definition.rb
+++ b/templates/windows-2008R2-serverstandard-amd64/definition.rb
@@ -12,8 +12,8 @@ Veewee::Session.declare({
     :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
 
     :floppy_files => [
-      "Autounattend.xml", # automate install and setup winrm
-      "install-cygwin-sshd.bat",
+      "Autounattend.xml", 
+      "install-cygwin-sshd.bat",               
       "install-winrm.bat",
       "oracle-cert.cer"],
 
@@ -30,7 +30,7 @@ Veewee::Session.declare({
     :ssh_login_timeout => "10000",
     # Actively attempt to winrm (no ssh on base windows) in for 10000 seconds
     :ssh_user => "vagrant", :ssh_password => "vagrant", :ssh_key => "", 
-    :ssh_host_port => "59856", :ssh_guest_port => "5985",
+    :ssh_host_port => "59856", :ssh_guest_port => "22",
     # And run postinstall.sh for up to 10000 seconds
     :postinstall_timeout => "10000",
     :postinstall_files => ["postinstall.sh"],

--- a/templates/windows-2008R2-serverstandard-amd64/install-cygwin-sshd.bat
+++ b/templates/windows-2008R2-serverstandard-amd64/install-cygwin-sshd.bat
@@ -2,13 +2,14 @@ REM http://webcache.googleusercontent.com/search?q=cache:SjoPPpuQxuoJ:www.tcm.ph
 
 REM create the cygwin directory
 cmd /c mkdir %SystemDrive%\cygwin
-copy a:\cygwin-setup.exe %SystemDrive%\cygwin
+
+cmd /c bitsadmin /transfer CygwinSetupExe /download /priority normal http://www.cygwin.com/setup.exe %SystemDrive%\cygwin\cygwin-setup.exe
 
 REM goto a temp directory
 cd %SystemDrive%\windows\temp
 
 REM run the installation
-cmd /c a:/cygwin-setup.exe -q -R %SystemDrive%\cygwin -P openssh,openssl,curl,cygrunsrv,wget,rebase,vim -s http://cygwin.mirrors.pair.com
+cmd /c %SystemDrive%\cygwin\cygwin-setup.exe -q -R %SystemDrive%\cygwin -P openssh,openssl,curl,cygrunsrv,wget,rebase,vim -s http://cygwin.mirrors.pair.com
 
 %SystemDrive%\cygwin\bin\bash -c 'PATH=/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin cygrunsrv -R sshd'
 


### PR DESCRIPTION
Hi,

Just wanted to let you know about a couple of issues I have encountered while created a base box for the windows-2008R2-serverstandard-amd64 template.

First two that I have been able to solve myself:

1) the ssh guest port was configured as 5985 instead of 22

2) the script assumes that cygwin-setup.exe exists on the floppy drive

I have attached a pull request to correct both issues.

Then some that I haven't been able to solve but for which a workaround exists:

Have a look at the end of the console output following the 'veewee vbox build' command:
"
- net.exe use '\vboxsvr\veewee-validation'
  System error 67 has occurred.

The network name cannot be found.
- shutdown.exe /r /t 0 /d p:2:4 /c 'Vagrant initial reboot'
  Waiting for ssh login on 127.0.0.1 with user vagrant to sshd on port => 59856 to work, timeout=10000 sec 
  "

No idea why error 67 is thrown as all seems fine on the guest. I guess this file share serves for smoke testing because all seems to be installed fine.

And finally the shutdown command doesn't work so the call hangs on the ssh login. Manually rebooting the guest allows the call to continue and finish successfully (the box ... was built succesfully!)

But other than these minor issues I have been very pleased with veewee!

Kind regards,

Niek.
