### PR TITLE
Fix typo: orginal to original

### DIFF
--- a/lib/fission.old/error.rb
+++ b/lib/fission.old/error.rb
@@ -1,9 +1,10 @@
 module Fission
     class Error < StandardError
-      attr_reader :orginal
+      attr_reader :original
       def initialize(msg, original=$!)
         super(msg)
-        @original = original; end
+        @original = original
+      end
     end
 end
 

--- a/lib/veewee/error.rb
+++ b/lib/veewee/error.rb
@@ -1,6 +1,6 @@
 module Veewee
   class Error < StandardError
-    attr_reader :orginal
+    attr_reader :original
 
     def initialize(msg, original = $!)
       super(msg)


### PR DESCRIPTION
Due to the typo, those attr_reader didn't work
