### PR TITLE
Avoid writing new lines on ssh output

### DIFF
--- a/lib/veewee/provider/core/helper/ssh.rb
+++ b/lib/veewee/provider/core/helper/ssh.rb
@@ -110,7 +110,7 @@ module Veewee
                   ch.on_data do |c, data|
                     stdout+=data
 
-                    ui.info data unless options[:mute]
+                    ui.info(data, :new_line => false) unless options[:mute]
 
                   end
 
@@ -119,7 +119,7 @@ module Veewee
                   ch.on_extended_data do |c, type, data|
                     stderr+=data
 
-                    ui.info data unless options[:mute]
+                    ui.info(data, :new_line => false) unless options[:mute]
 
                   end
 


### PR DESCRIPTION
When streaming SSH output, veewee currently is always appending a new line to whatever packet is being printed. Since the output already contains new lines, the behavior results in multiple prints of a line that the remote end is intending to rewrite (with a \r), and results in excess new lines being added.

Two cases... carriage returns breaking

```
Fetching: ohai-6.16.0.gem
Fetching: ohai-6.16.0.gem (  1%)
Fetching: ohai-6.16.0.gem (  4%)
Fetching: ohai-6.16.0.gem (  5%)
Fetching: ohai-6.16.0.gem (  6%)
Fetching: ohai-6.16.0.gem (  7%)
Fetching: ohai-6.16.0.gem (  8%)
Fetching: ohai-6.16.0.gem (  9%)
Fetching: ohai-6.16.0.gem ( 10%)
```

Excess new lines

```
make[2]: Entering directory `/tmp/ruby-1.9.3-p286/ext/json'

installing default libraries

make[2]: Leaving directory `/tmp/ruby-1.9.3-p286/ext/json'

make[2]: Entering directory `/tmp/ruby-1.9.3-p286/ext/json/generator'

compiling generator.c
```

In `ui.rb`, there already is the option for not including a new line. I simply added it to the two calls to `ui.info` in `Veewee::Provider::Core::Helper::Ssh.ssh_execute`.
