### PR TITLE
Fix puppet.sh scripts to actually honor PUPPET_VERSION

### DIFF
--- a/templates/.ubuntu/puppet.sh
+++ b/templates/.ubuntu/puppet.sh
@@ -7,8 +7,6 @@ fi
 adduser --system --group --home /var/lib/puppet puppet
 
 # Installing Puppet
-gem install puppet --no-ri --no-rdoc
-
 if [ -z "$PUPPET_VERSION" ]; then
   # Default to latest
   gem install puppet --no-ri --no-rdoc

--- a/templates/Debian-7.0-rc1-amd64-netboot/puppet.sh
+++ b/templates/Debian-7.0-rc1-amd64-netboot/puppet.sh
@@ -7,8 +7,6 @@ fi
 adduser --system --group --home /var/lib/puppet puppet
 
 # Installing Puppet
-gem install puppet --no-ri --no-rdoc
-
 if [ -z "$PUPPET_VERSION" ]; then
   # Default to latest
   gem install puppet --no-ri --no-rdoc

--- a/templates/ubuntu-12.10-server-amd64-packages/puppet.sh
+++ b/templates/ubuntu-12.10-server-amd64-packages/puppet.sh
@@ -7,8 +7,6 @@ fi
 adduser --system --group --home /var/lib/puppet puppet
 
 # Installing Puppet
-gem install puppet --no-ri --no-rdoc
-
 if [ -z "$PUPPET_VERSION" ]; then
   # Default to latest
   gem install puppet --no-ri --no-rdoc

--- a/templates/ubuntu-12.10-server-i386-packages/puppet.sh
+++ b/templates/ubuntu-12.10-server-i386-packages/puppet.sh
@@ -7,8 +7,6 @@ fi
 adduser --system --group --home /var/lib/puppet puppet
 
 # Installing Puppet
-gem install puppet --no-ri --no-rdoc
-
 if [ -z "$PUPPET_VERSION" ]; then
   # Default to latest
   gem install puppet --no-ri --no-rdoc


### PR DESCRIPTION
There are some puppet.sh scripts that execute `gem install puppet` prior to
evaluating `PUPPET_VERSION`. This results in installing the latest version of
Puppet instead of the one specified in `PUPPET_VERSION`.
