### PR TITLE
Reboot VM instead of Shutdown

### DIFF
--- a/templates/windows-7-professional-amd64/postinstall.sh
+++ b/templates/windows-7-professional-amd64/postinstall.sh
@@ -54,7 +54,7 @@ alias ruby="ruby.exe"
 alias puppet="puppet.bat"
 alias ohai="ohai.bat"
 alias irb="irb.bat"
-alias facter="facter.bat" 
+alias facter="facter.bat"
 EOF
 
 
@@ -70,5 +70,5 @@ net.exe use  '\\vboxsvr\veewee-validation'
 
 # Reboot
 # http://www.techrepublic.com/blog/datacenter/restart-windows-server-2003-from-the-command-line/245
-shutdown.exe /s /t 0 /d p:2:4 /c "Vagrant initial reboot"
+shutdown.exe /r /t 0 /d p:2:4 /c "Vagrant initial reboot"
 


### PR DESCRIPTION
Fix a small but yet powerful typo in the `shutdown.exe` command within `postinstall.sh`:

```
shutdown.exe /s 
```

gets

```
shutdown.exe /r
```

Now the machine gets rebooted as intended and veewee can execute the postinstall script completely.

The prior command shut down the machine so the command could not finish completely which results in an ugly 'Authentication failure'.

The patch can probably applied on every Windows template but I didn't test it through.

PS: Never thought I'd create a pull request for a windows box but, hey, here it is :)
