### PR TITLE
Support cygwin style file path for VBoxManage arguments

### DIFF
--- a/lib/veewee/platform.rb
+++ b/lib/veewee/platform.rb
@@ -1,0 +1,21 @@
+module Veewee
+  class Platform
+
+    def initialize(host_os)
+      @host_os = host_os.downcase
+    end
+
+    def to_native_path(path)
+      return cygwin? ? `cygpath --windows "#{path}"`.chomp : path
+    end
+
+    def cygwin?
+      @host_os.include?('cygwin')
+    end
+
+    def self.host
+      Platform.new(RbConfig::CONFIG['host_os'])
+    end
+
+  end
+end

--- a/lib/veewee/provider/virtualbox/box/export_vagrant.rb
+++ b/lib/veewee/provider/virtualbox/box/export_vagrant.rb
@@ -110,7 +110,8 @@ module Veewee
             end
 
             ui.info "Exporting the box"
-            command = "#{@vboxcmd} export #{name} --output #{File.join(tmp_dir,'box.ovf')}"
+            platform = Platform.host
+            command = "#{@vboxcmd} export #{name} --output \"#{platform.to_native_path(File.join(tmp_dir,'box.ovf'))}\""
             env.logger.debug("Command: #{command}")
             shell_exec(command, {:mute => false})
 
@@ -118,7 +119,7 @@ module Veewee
             FileUtils.cd(tmp_dir)
             command_box_path = box_path
             is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
-            if is_windows
+            if is_windows && !platform.cygwin?
               command_box_path = command_box_path.gsub(/^([A-Z])\:\/(.*)$/, '/\1/\2')
             end
             command = "tar -cvf '#{command_box_path}' ."


### PR DESCRIPTION
In cygwin world, file path style is like UNIX style. ("c:\foo\bar" -> "/cygdrive/c/foo/bar")
But normal windows executable cannot recognize this style, so before execute VBoxManage, convert from cygwin style path to windows style are needed.
- check RbConfig::CONFIG['host_os'] for cygwin world or not
- if in cygwin world, before execute VBoxManager, convert file path by cygpath tool
