### PR TITLE
Changing vmfusion ostype from `FreeBSD_64` to `freebsd-64` to prevent er...

### DIFF
--- a/lib/veewee/config/ostypes.yml
+++ b/lib/veewee/config/ostypes.yml
@@ -110,7 +110,7 @@ FreeBSD:
   :vbox: FreeBSD
   :parallels: freebsd
 FreeBSD_64:
-  :fusion: FreeBSD_64
+  :fusion: freebsd-64
   :kvm:
   :vbox: FreeBSD_64
   :parallels: freebsd


### PR DESCRIPTION
When I use `:os_type_id => 'FreeBSD64'` in my `definition.rb` with the vmfusion provider, I get the following error in VMware Fusion:

```
Guest operating system 'freebsd_64' is not supported
Select a guest operating system from the main page of Virtual Machine Settings.
```

Changing the `:fusion` ostype for FreeBSD_64 to `freebsd-64` (instead of `FreeBSD_64` appears to fix the issue)
