### PR TITLE
Solaris 10: Seperate config management

### DIFF
--- a/templates/solaris-10-ga-x86/chef.sh
+++ b/templates/solaris-10-ga-x86/chef.sh
@@ -1,0 +1,10 @@
+# Chef needs these
+/opt/csw/bin/pkgutil -y -i CSWgmake
+/opt/csw/bin/pkgutil -y -i CSWgcc4g++ CSWgcc4core
+
+# These are needed to get a compiler working
+# Mainly because chef depends on compiling some native gems
+PATH=/opt/csw/bin:/opt/csw/gnu/:/opt/csw/gcc4/bin:$PATH
+export PATH
+
+/opt/csw/bin/gem install chef  --no-ri --no-rdoc

--- a/templates/solaris-10-ga-x86/definition.rb
+++ b/templates/solaris-10-ga-x86/definition.rb
@@ -28,5 +28,11 @@ Veewee::Definition.declare({
   :ssh_host_port => "7222", :ssh_guest_port => "22",
   :sudo_cmd => "pfexec bash -l %f",
   :shutdown_cmd => "/usr/sbin/poweroff",
-  :postinstall_files => [ "postinstall.sh" , "cleanup.sh" ], :postinstall_timeout => 10000
+  :postinstall_files => [
+    "postinstall.sh",
+    "puppet.sh",
+    "chef.sh",
+    "cleanup.sh"
+  ],
+  :postinstall_timeout => 10000
 })

--- a/templates/solaris-10-ga-x86/postinstall.sh
+++ b/templates/solaris-10-ga-x86/postinstall.sh
@@ -53,25 +53,6 @@ echo "LookupClientHostnames=no" >> /etc/ssh/sshd_config
 #/opt/csw/sbin/alternatives --display rbconfig18
 #/opt/csw/sbin/alternatives --set rbconfig18 /opt/csw/lib/ruby/1.8/i386-solaris2.9/rbconfig.rb.gcc4
 
-# Chef needs these
-/opt/csw/bin/pkgutil -y -i CSWgmake
-/opt/csw/bin/pkgutil -y -i CSWgcc4g++ CSWgcc4core
-
-# Puppet needs these
-/opt/csw/bin/pkgutil -y -i CSWaugeas
-/opt/csw/bin/pkgutil -y -i CSWrubyaugeas
-
-
-# These are needed to get a compiler working
-# Mainly because chef depends on compiling some native gems
-PATH=/opt/csw/bin:/opt/csw/gnu/:/opt/csw/gcc4/bin:$PATH
-export PATH
-
-## Let's get Puppet and Chef
-/opt/csw/bin/gem install puppet  --no-ri --no-rdoc
-/opt/csw/bin/gem install chef  --no-ri --no-rdoc
-
-
 
 ## Fix the shells to include the /opt/csw and /usr/ucb directories
 /opt/csw/bin/gsed -i -e 's#^\#PATH=.*$#PATH=/opt/csw/bin:/usr/sbin:/usr/bin:/usr/ucb#g' \

--- a/templates/solaris-10-ga-x86/puppet.sh
+++ b/templates/solaris-10-ga-x86/puppet.sh
@@ -1,0 +1,4 @@
+/opt/csw/bin/pkgutil -y -i CSWaugeas
+/opt/csw/bin/pkgutil -y -i CSWrubyaugeas
+
+/opt/csw/bin/gem install puppet  --no-ri --no-rdoc


### PR DESCRIPTION
Having Puppet and Chef installs in seperate scripts makes it simple to enable or
disable config management by adding comments to `definition.rb`.
