### PR TITLE
Apply shift to entire sequence.

### DIFF
--- a/lib/veewee/provider/parallels/box/helper/console_type.rb
+++ b/lib/veewee/provider/parallels/box/helper/console_type.rb
@@ -47,9 +47,10 @@ module Veewee
         def shift(sequence)
           seq=Array.new
           seq << press_key('SHIFT_LEFT')
-          sequence.each_char do |s|
-            seq << s
-          end
+
+          # We never apply SHIFT_LEFT to more than one logical character at a
+          # time
+          seq << sequence
           return seq
         end
 


### PR DESCRIPTION
References #663. We never call shift on more than logical character.

This fixes `:` being sent as `Colon`. I discovered in the debug output that we were actually sending `SHIFT#C O L O N`. Traced it back to this, checked all of our calls to `shift`, and found that we had no use for character-wise parsing. I don't know why that was added, but I am confident that I haven't broken anything.
