### PR TITLE
Fix path to Parallels Tools.

### DIFF
--- a/lib/veewee/provider/parallels/box/helper/buildinfo.rb
+++ b/lib/veewee/provider/parallels/box/helper/buildinfo.rb
@@ -15,12 +15,14 @@ module Veewee
         def guest_iso_path
           # So we begin by transferring the ISO file of the vmware tools
 
+          parallels_base_path = "/Applications/Parallels Desktop.app/Contents/Resources/Tools"
+
           # Set default
-          iso_image="/Library/Parallels/Tools/prl-tools-lin.iso"
-          iso_image="/Library/Parallels/Tools/prl-tools-mac.iso" if definition.os_type_id=~/^Darwin/
-          iso_image="/Library/Parallels/Tools/prl-tools-win.iso" if definition.os_type_id=~/^Win/
-          iso_image="/Library/Parallels/Tools/prl-tools-other.iso" if definition.os_type_id=~/^Free/
-          iso_image="/Library/Parallels/Tools/prl-tools-other.iso" if definition.os_type_id=~/^Solaris/
+          iso_image="#{parallels_base_path}/prl-tools-lin.iso"
+          iso_image="#{parallels_base_path}/prl-tools-mac.iso" if definition.os_type_id=~/^Darwin/
+          iso_image="#{parallels_base_path}/prl-tools-win.iso" if definition.os_type_id=~/^Win/
+          iso_image="#{parallels_base_path}/prl-tools-other.iso" if definition.os_type_id=~/^Free/
+          iso_image="#{parallels_base_path}/prl-tools-other.iso" if definition.os_type_id=~/^Solaris/
           return iso_image
 
         end


### PR DESCRIPTION
My build failed because veewee looked for Parallels Tools in the wrong place. While one could symlink the actual tools to the right place, I've gone ahead and updated the path. Confirmed it works.
