### PR TITLE
Bump Ruby version to 1.9.3

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,4 +1,4 @@
-rvm use ruby-1.9.2@veewee --create
+rvm use ruby-1.9.3@veewee --create
 #rvm use ruby-1.8.7@veewee --create
 
 alias veewee="bundle exec veewee"


### PR DESCRIPTION
OS X 10.8 doesn't have a build, and for some reason RVM doesn't want to build it from source:

```
$ rvm install ruby-1.9.2-p320
No binary rubies available for: osx/10.8/x86_64/ruby-1.9.2-p320.
Continuing with compilation. Please read 'rvm mount' to get more information on binary rubies.
The provided compiler '/usr/bin/gcc' is LLVM based, it is not yet fully supported by ruby and gems, please read `rvm requirements`.
```

1.9.3 seems to work just fine so far.
