### PR TITLE
URLs for CentOS ISOs are not working. Replaced with recommended mirror.

### DIFF
--- a/templates/CentOS-5.5-i386-netboot/definition.rb
+++ b/templates/CentOS-5.5-i386-netboot/definition.rb
@@ -3,7 +3,7 @@ Veewee::Session.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat',
   :iso_file => "CentOS-5.5-i386-netinstall.iso",
-  :iso_src => "http://vault.centos.org/5.5/isos/i386/CentOS-5.5-i386-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.5/isos/i386/CentOS-5.5-i386-netinstall.iso",
   :iso_md5 => "0172883a3039772165db073693debae5",
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.5-x86_64-netboot/definition.rb
+++ b/templates/CentOS-5.5-x86_64-netboot/definition.rb
@@ -3,7 +3,7 @@ Veewee::Session.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-5.5-x86_64-netinstall.iso",
-  :iso_src => "http://vault.centos.org/5.5/isos/x86_64/CentOS-5.5-x86_64-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.5/isos/x86_64/CentOS-5.5-x86_64-netinstall.iso",
   :iso_md5 => "560a964657c92508ae110a35cb963632",
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.6-i386-netboot/definition.rb
+++ b/templates/CentOS-5.6-i386-netboot/definition.rb
@@ -3,7 +3,7 @@ Veewee::Definition.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat',
   :iso_file => "CentOS-5.6-i386-netinstall.iso",
-  :iso_src => "http://vault.centos.org/5.6/isos/i386/CentOS-5.6-i386-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.6/isos/i386/CentOS-5.6-i386-netinstall.iso",
   :iso_md5 => "a710105f7f9fe3516f08f6f8514ed2b0",
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.6-x86_64-netboot-packages/definition.rb
+++ b/templates/CentOS-5.6-x86_64-netboot-packages/definition.rb
@@ -3,7 +3,7 @@ Veewee::Definition.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-5.6-x86_64-netinstall.iso",
-  :iso_src => "http://vault.centos.org/5.6/isos/x86_64/CentOS-5.6-x86_64-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.6/isos/x86_64/CentOS-5.6-x86_64-netinstall.iso",
   :iso_md5 => "02cf3a5e32aaa5eed27af775ad292beb",
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.6-x86_64-netboot/definition.rb
+++ b/templates/CentOS-5.6-x86_64-netboot/definition.rb
@@ -3,7 +3,7 @@ Veewee::Definition.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-5.6-x86_64-netinstall.iso",
-  :iso_src => "http://vault.centos.org/5.6/isos/x86_64/CentOS-5.6-x86_64-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.6/isos/x86_64/CentOS-5.6-x86_64-netinstall.iso",
   :iso_md5 => "02cf3a5e32aaa5eed27af775ad292beb",
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.7-i386-netboot/definition.rb
+++ b/templates/CentOS-5.7-i386-netboot/definition.rb
@@ -3,7 +3,7 @@ Veewee::Session.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat',
   :iso_file => "CentOS-5.7-i386-netinstall.iso",
-  :iso_src => "http://vault.centos.org/5.7/isos/i386/CentOS-5.7-i386-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.7/isos/i386/CentOS-5.7-i386-netinstall.iso",
   :iso_md5 => "11222d9134cdfc101f6f91fe544254c9",
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.7-x86_64-netboot/definition.rb
+++ b/templates/CentOS-5.7-x86_64-netboot/definition.rb
@@ -3,7 +3,7 @@ Veewee::Session.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-5.7-x86_64-netinstall.iso",
-  :iso_src => "http://vault.centos.org/5.7/isos/x86_64/CentOS-5.7-x86_64-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.7/isos/x86_64/CentOS-5.7-x86_64-netinstall.iso",
   :iso_md5 => "5db3d49ba7a2c56810822914fadc1edf",
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.8-i386-netboot/definition.rb
+++ b/templates/CentOS-5.8-i386-netboot/definition.rb
@@ -3,7 +3,7 @@ Veewee::Session.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat',
   :iso_file => "CentOS-5.8-i386-netinstall.iso",
-  :iso_src => "http://vault.centos.org/5.8/isos/i386/CentOS-5.8-i386-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.8/isos/i386/CentOS-5.8-i386-netinstall.iso",
   :iso_md5 => "3812865e426b55fde9a9931990e4a16c",
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.8-i386/definition.rb
+++ b/templates/CentOS-5.8-i386/definition.rb
@@ -3,7 +3,7 @@ Veewee::Session.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat',
   :iso_file => "CentOS-5.8-i386-bin-DVD-1of2.iso",
-  :iso_src => "http://vault.centos.org/5.8/isos/i386/CentOS-5.8-i386-bin-DVD-1of2.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.8/isos/i386/CentOS-5.8-i386-bin-DVD-1of2.iso",
   :iso_md5 => "0fdd45c43b5d8fb9e05f4255c5855f9c",
   :iso_download_timeout => 10000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.8-x86_64-netboot/definition.rb
+++ b/templates/CentOS-5.8-x86_64-netboot/definition.rb
@@ -3,7 +3,7 @@ Veewee::Session.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-5.8-x86_64-netinstall.iso",
-  :iso_src => "http://vault.centos.org/5.8/isos/x86_64/CentOS-5.8-x86_64-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.8/isos/x86_64/CentOS-5.8-x86_64-netinstall.iso",
   :iso_md5 => "6425035e9adee4b8653a85f59877ac5b",
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-5.8-x86_64/definition.rb
+++ b/templates/CentOS-5.8-x86_64/definition.rb
@@ -3,7 +3,7 @@ Veewee::Session.declare({
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-5.8-x86_64-bin-DVD-1of2.iso",
-  :iso_src => "http://vault.centos.org/5.8/isos/x86_64/CentOS-5.8-x86_64-bin-DVD-1of2.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/5.8/isos/x86_64/CentOS-5.8-x86_64-bin-DVD-1of2.iso",
   :iso_md5 => "8a3bf0030f192022943f83fe6b2cf373",
   :iso_download_timeout => 10000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],

--- a/templates/CentOS-6.0-i386-netboot/definition.rb
+++ b/templates/CentOS-6.0-i386-netboot/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.0-i386-netinstall.iso",
-  :iso_src => "http://vault.centos.org/6.0/isos/i386/CentOS-6.0-i386-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.0/isos/i386/CentOS-6.0-i386-netinstall.iso",
   :iso_md5 => "65731c29c49630dea6cde103d02ccffb",
   :iso_download_timeout => 1000,
   :boot_wait => "15",

--- a/templates/CentOS-6.0-i386/definition.rb
+++ b/templates/CentOS-6.0-i386/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.0-i386-bin-DVD.iso", 
-  :iso_src => "http://vault.centos.org/6.0/isos/i386/CentOS-6.0-i386-bin-DVD.iso", 
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.0/isos/i386/CentOS-6.0-i386-bin-DVD.iso", 
   :iso_md5 => "d7e57d6edaca1556d5bad2fa88602309",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/templates/CentOS-6.0-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.0-x86_64-minimal/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.0-x86_64-minimal.iso",
-  :iso_src => "http://vault.centos.org/6.0/isos/x86_64/CentOS-6.0-x86_64-minimal.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.0/isos/x86_64/CentOS-6.0-x86_64-minimal.iso",
   :iso_md5 => "b9fff4dad7aad0edaa564d7a251cb971",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/templates/CentOS-6.0-x86_64-netboot/definition.rb
+++ b/templates/CentOS-6.0-x86_64-netboot/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.0-x86_64-netinstall.iso",
-  :iso_src => "http://vault.centos.org/6.0/isos/x86_64/CentOS-6.0-x86_64-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.0/isos/x86_64/CentOS-6.0-x86_64-netinstall.iso",
   :iso_md5 => "d13da95c29e585ee15cf403b89468243",
   :iso_download_timeout => 1000,
   :boot_wait => "15",

--- a/templates/CentOS-6.0-x86_64/definition.rb
+++ b/templates/CentOS-6.0-x86_64/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.0-x86_64-bin-DVD1.iso",
-  :iso_src => "http://vault.centos.org/6.0/isos/x86_64/CentOS-6.0-x86_64-bin-DVD1.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.0/isos/x86_64/CentOS-6.0-x86_64-bin-DVD1.iso",
   :iso_md5 => "7c148e0a1b330186adef66ee3e2d433d",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/templates/CentOS-6.1-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.1-x86_64-minimal/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.1-x86_64-minimal.iso",
-  :iso_src => "http://vault.centos.org/6.1/isos/x86_64/CentOS-6.1-x86_64-minimal.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.1/isos/x86_64/CentOS-6.1-x86_64-minimal.iso",
   :iso_md5 => "03177dfefb4ebfeb03f457c29f00b0a1",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/templates/CentOS-6.1-x86_64-netboot/definition.rb
+++ b/templates/CentOS-6.1-x86_64-netboot/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.1-x86_64-netinstall.iso",
-  :iso_src => "http://vault.centos.org/6.1/isos/x86_64/CentOS-6.1-x86_64-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.1/isos/x86_64/CentOS-6.1-x86_64-netinstall.iso",
   :iso_md5 => "b0366858089526fb025f0da4abf6d732",
   :iso_download_timeout => 1000,
   :boot_wait => "15",

--- a/templates/CentOS-6.2-i386-minimal/definition.rb
+++ b/templates/CentOS-6.2-i386-minimal/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.2-i386-minimal.iso",
-  :iso_src => "http://vault.centos.org/6.2/isos/i386/CentOS-6.2-i386-minimal.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.2/isos/i386/CentOS-6.2-i386-minimal.iso",
   :iso_md5 => "cc4fbd16bd305f5bf6731b4b10f8fd18",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/templates/CentOS-6.2-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.2-x86_64-minimal/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.2-x86_64-minimal.iso",
-  :iso_src => "http://vault.centos.org/6.2/isos/x86_64/CentOS-6.2-x86_64-minimal.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.2/isos/x86_64/CentOS-6.2-x86_64-minimal.iso",
   :iso_md5 => "20dac370a6e08ded2701e4104855bc6e",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/templates/CentOS-6.2-x86_64-netboot/definition.rb
+++ b/templates/CentOS-6.2-x86_64-netboot/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-6.2-x86_64-netinstall.iso",
-  :iso_src => "http://vault.centos.org/6.2/isos/x86_64/CentOS-6.2-x86_64-netinstall.iso",
+  :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.2/isos/x86_64/CentOS-6.2-x86_64-netinstall.iso",
   :iso_md5 => "7e7f4161a5c8c49032655e5f4ecd1f07",
   :iso_download_timeout => 1000,
   :boot_wait => "15",


### PR DESCRIPTION
Direct links to ISOs on vault.centos.org redirect to http://vault.centos.org/notonvault.html with instructions to use mirror.symnds.com for ISO downloads. 

Updated all references to vault.centos.org ISOs, but left vault.centos.org for supporting files (these resources are still available on vault.centos.org). 

I _did_ individually check that all the ISO links work, but I did _not_ build and test images for each of the ISOs using veewee. If there is a recommended way to do this I can give it a try, but just switching out the ISO URLs with a mirror hopefully won't require that level of testing.
