### PR TITLE
Fix problem building VM for Debian 5.X from archive.debian.org

### DIFF
--- a/templates/Debian-5.0.10-amd64-netboot/preseed.cfg
+++ b/templates/Debian-5.0.10-amd64-netboot/preseed.cfg
@@ -213,7 +213,9 @@ d-i apt-setup/security_host string archive.debian.org/debian-security
 # By default the installer requires that repositories be authenticated
 # using a known gpg key. This setting can be used to disable that
 # authentication. Warning: Insecure, not recommended.
-#d-i debian-installer/allow_unauthenticated string true
+# GPG Keys are now obsolete on archive for Lenny so you must
+# accept this insecure setup
+d-i debian-installer/allow_unauthenticated string true
 
 ### Package selection
 tasksel tasksel/first multiselect standard

--- a/templates/Debian-5.0.10-i386-netboot/preseed.cfg
+++ b/templates/Debian-5.0.10-i386-netboot/preseed.cfg
@@ -213,7 +213,9 @@ d-i apt-setup/security_host string archive.debian.org/debian-security
 # By default the installer requires that repositories be authenticated
 # using a known gpg key. This setting can be used to disable that
 # authentication. Warning: Insecure, not recommended.
-#d-i debian-installer/allow_unauthenticated string true
+# GPG Keys are now obsolete on archive for Lenny so you must
+# accept this insecure setup
+d-i debian-installer/allow_unauthenticated string true
 
 ### Package selection
 tasksel tasksel/first multiselect standard

--- a/templates/Debian-5.0.8-amd64-netboot/preseed.cfg
+++ b/templates/Debian-5.0.8-amd64-netboot/preseed.cfg
@@ -213,7 +213,9 @@ d-i apt-setup/security_host string archive.debian.org/debian-security
 # By default the installer requires that repositories be authenticated
 # using a known gpg key. This setting can be used to disable that
 # authentication. Warning: Insecure, not recommended.
-#d-i debian-installer/allow_unauthenticated string true
+# GPG Keys are now obsolete on archive for Lenny so you must
+# accept this insecure setup
+d-i debian-installer/allow_unauthenticated string true
 
 ### Package selection
 tasksel tasksel/first multiselect standard

--- a/templates/Debian-5.0.8-i386-netboot/preseed.cfg
+++ b/templates/Debian-5.0.8-i386-netboot/preseed.cfg
@@ -213,7 +213,9 @@ d-i apt-setup/security_host string archive.debian.org/debian-security
 # By default the installer requires that repositories be authenticated
 # using a known gpg key. This setting can be used to disable that
 # authentication. Warning: Insecure, not recommended.
-#d-i debian-installer/allow_unauthenticated string true
+# GPG Keys are now obsolete on archive for Lenny so you must
+# accept this insecure setup
+d-i debian-installer/allow_unauthenticated string true
 
 ### Package selection
 tasksel tasksel/first multiselect standard


### PR DESCRIPTION
If you try to build an old Debian release from archive.debian.org you get stucked in the middle of the installation. The installer ask for using unauthenticated packages as the GPG key are now obsolete.
This patch allow unsecure package at installation.
This should fix issue #631
