### PR TITLE
Use recent rubygems to pass chef and puppet validation

### DIFF
--- a/templates/Debian-5.0.10-amd64-netboot/ruby.sh
+++ b/templates/Debian-5.0.10-amd64-netboot/ruby.sh
@@ -1,11 +1,12 @@
-#Installing ruby
+# Installing ruby from packages
 apt-get -y install ruby ruby1.8-dev libopenssl-ruby1.8 rdoc ri irb make g++ libshadow-ruby1.8
 
-# Install RubyGems 1.7.2
-wget http://production.cf.rubygems.org/rubygems/rubygems-1.7.2.tgz
-tar xzf rubygems-1.7.2.tgz
-cd rubygems-1.7.2
+# Install RubyGems 1.8.25
+rg_ver=1.8.25
+wget http://production.cf.rubygems.org/rubygems/rubygems-${rg_ver}.tgz
+tar xzf rubygems-${rg_ver}.tgz
+cd rubygems-${rg_ver}
 /usr/bin/ruby setup.rb
 cd ..
-rm -rf rubygems-1.7.2*
+rm -rf rubygems-${rg_ver}*
 ln -sfv /usr/bin/gem1.8 /usr/bin/gem

--- a/templates/Debian-5.0.10-i386-netboot/ruby.sh
+++ b/templates/Debian-5.0.10-i386-netboot/ruby.sh
@@ -1,11 +1,12 @@
-#Installing ruby
+# Installing ruby from packages
 apt-get -y install ruby ruby1.8-dev libopenssl-ruby1.8 rdoc ri irb make g++ libshadow-ruby1.8
 
-# Install RubyGems 1.7.2
-wget http://production.cf.rubygems.org/rubygems/rubygems-1.7.2.tgz
-tar xzf rubygems-1.7.2.tgz
-cd rubygems-1.7.2
+# Install RubyGems 1.8.25
+rg_ver=1.8.25
+wget http://production.cf.rubygems.org/rubygems/rubygems-${rg_ver}.tgz
+tar xzf rubygems-${rg_ver}.tgz
+cd rubygems-${rg_ver}
 /usr/bin/ruby setup.rb
 cd ..
-rm -rf rubygems-1.7.2*
+rm -rf rubygems-${rg_ver}*
 ln -sfv /usr/bin/gem1.8 /usr/bin/gem


### PR DESCRIPTION
Rubygem 1.7.2 did not pass chef and puppet validation so upgrade to 1.8.25
