### PR TITLE
Rake Test Target Tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ virtualfloppy.vfd
 *.swp
 AutoPartition.app
 .rbenv-gemsets
+
+screenshot-auto-*.png


### PR DESCRIPTION
In the iso target added a test to only perform the test on the template name that matches a supplied :template_name.

In the autotest target now compare with the File.basename rather than the full template name including the template path prefix.

Ex:
rake 'iso[gentoo-latest-i386-experimental]'
rake 'autotest[gentoo-latest-i386-experimental]'
