### PR TITLE
Allow veewee to install aside vagrant

### DIFF
--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "popen4", "~> 0.1.2"
   s.add_dependency "thor", "~> 0.15"
   s.add_dependency "highline"
-  s.add_dependency "json"
+  s.add_dependency "json", ">= 1.5.1", "< 1.8.0"
   s.add_dependency "progressbar"
   s.add_dependency "i18n"
   #s.add_dependency "cucumber", ">=1.0.0"


### PR DESCRIPTION
Fixes JSON incompatibility errors with latest bundlers

Ex:

``` bash
Resolving dependencies...
Bundler could not find compatible versions for gem "json":
  In Gemfile:
    vagrant (>= 0) ruby depends on
      json (< 1.8.0, >= 1.5.1) ruby

    veewee (>= 0) ruby depends on
      json (1.8.0)

```
