### PR TITLE
centos: extend timeout and bump ruby version

### DIFF
--- a/templates/CentOS-5.5-i386-netboot/definition.rb
+++ b/templates/CentOS-5.5-i386-netboot/definition.rb
@@ -8,7 +8,7 @@ Veewee::Session.declare({
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],
   :kickstart_port => "7122", :kickstart_timeout => 10000, :kickstart_file => "ks.cfg",
-  :ssh_login_timeout => "600", :ssh_user => "vagrant", :ssh_password => "vagrant", :ssh_key => "",
+  :ssh_login_timeout => "10000", :ssh_user => "vagrant", :ssh_password => "vagrant", :ssh_key => "",
   :ssh_host_port => "7222", :ssh_guest_port => "22",
   :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
   :shutdown_cmd => "/sbin/halt -h -p",

--- a/templates/CentOS-5.5-i386-netboot/postinstall.sh
+++ b/templates/CentOS-5.5-i386-netboot/postinstall.sh
@@ -22,14 +22,14 @@ yum -y clean all
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.5-x86_64-netboot/definition.rb
+++ b/templates/CentOS-5.5-x86_64-netboot/definition.rb
@@ -8,7 +8,7 @@ Veewee::Session.declare({
   :iso_download_timeout => 1000,
   :boot_wait => "10", :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],
   :kickstart_port => "7122", :kickstart_timeout => 10000, :kickstart_file => "ks.cfg",
-  :ssh_login_timeout => "600", :ssh_user => "vagrant", :ssh_password => "vagrant", :ssh_key => "",
+  :ssh_login_timeout => "10000", :ssh_user => "vagrant", :ssh_password => "vagrant", :ssh_key => "",
   :ssh_host_port => "7222", :ssh_guest_port => "22",
   :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
   :shutdown_cmd => "/sbin/halt -h -p",

--- a/templates/CentOS-5.5-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-5.5-x86_64-netboot/postinstall.sh
@@ -22,14 +22,14 @@ yum -y clean all
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.6-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-5.6-x86_64-netboot/postinstall.sh
@@ -23,14 +23,14 @@ yum -y clean all
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.7-i386-netboot/postinstall.sh
+++ b/templates/CentOS-5.7-i386-netboot/postinstall.sh
@@ -16,14 +16,14 @@ yum -y clean all
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.7-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-5.7-x86_64-netboot/postinstall.sh
@@ -22,14 +22,14 @@ yum -y clean all
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.8-i386-netboot/postinstall.sh
+++ b/templates/CentOS-5.8-i386-netboot/postinstall.sh
@@ -16,14 +16,14 @@ echo "UseDNS no" >> /etc/ssh/sshd_config
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.8-i386/postinstall.sh
+++ b/templates/CentOS-5.8-i386/postinstall.sh
@@ -16,14 +16,14 @@ echo "UseDNS no" >> /etc/ssh/sshd_config
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.8-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-5.8-x86_64-netboot/postinstall.sh
@@ -16,14 +16,14 @@ echo "UseDNS no" >> /etc/ssh/sshd_config
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.8-x86_64/postinstall.sh
+++ b/templates/CentOS-5.8-x86_64/postinstall.sh
@@ -22,14 +22,14 @@ yum -y clean all
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.9-i386-netboot/postinstall.sh
+++ b/templates/CentOS-5.9-i386-netboot/postinstall.sh
@@ -16,14 +16,14 @@ yum -y clean all
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.9-i386/postinstall.sh
+++ b/templates/CentOS-5.9-i386/postinstall.sh
@@ -16,14 +16,14 @@ yum -y clean all
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.9-x86_64-netboot/postinstall.sh
+++ b/templates/CentOS-5.9-x86_64-netboot/postinstall.sh
@@ -16,14 +16,14 @@ echo "UseDNS no" >> /etc/ssh/sshd_config
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 

--- a/templates/CentOS-5.9-x86_64/postinstall.sh
+++ b/templates/CentOS-5.9-x86_64/postinstall.sh
@@ -22,14 +22,14 @@ yum -y clean all
 
 #Installing ruby
 cd /tmp
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz || fail "Could not download Ruby source"
-tar xzvf ruby-1.9.2-p180.tar.gz 
-cd ruby-1.9.2-p180
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz || fail "Could not download Ruby source"
+tar xzvf ruby-1.9.3-p429.tar.gz 
+cd ruby-1.9.3-p429
 ./configure
 make && make install
 cd /tmp
-rm -rf /tmp/ruby-1.9.2-p180
-rm /tmp/ruby-1.9.2-p180.tar.gz
+rm -rf /tmp/ruby-1.9.3-p429
+rm /tmp/ruby-1.9.3-p429.tar.gz
 ln -s /usr/local/bin/ruby /usr/bin/ruby # Create a sym link for the same path
 ln -s /usr/local/bin/gem /usr/bin/gem # Create a sym link for the same path
 


### PR DESCRIPTION
ssh_login_timeout: 600 is too short
ruby 1.9.2 is a bit old
