### PR TITLE
updated CentOS6-x64 os_type_id so Fusion works

### DIFF
--- a/templates/CentOS-6.0-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.0-x86_64-minimal/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.0-x86_64-minimal.iso",
   :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.0/isos/x86_64/CentOS-6.0-x86_64-minimal.iso",
   :iso_md5 => "b9fff4dad7aad0edaa564d7a251cb971",

--- a/templates/CentOS-6.0-x86_64-netboot/definition.rb
+++ b/templates/CentOS-6.0-x86_64-netboot/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.0-x86_64-netinstall.iso",
   :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.0/isos/x86_64/CentOS-6.0-x86_64-netinstall.iso",
   :iso_md5 => "d13da95c29e585ee15cf403b89468243",

--- a/templates/CentOS-6.0-x86_64/definition.rb
+++ b/templates/CentOS-6.0-x86_64/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.0-x86_64-bin-DVD1.iso",
   :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.0/isos/x86_64/CentOS-6.0-x86_64-bin-DVD1.iso",
   :iso_md5 => "7c148e0a1b330186adef66ee3e2d433d",

--- a/templates/CentOS-6.1-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.1-x86_64-minimal/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.1-x86_64-minimal.iso",
   :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.1/isos/x86_64/CentOS-6.1-x86_64-minimal.iso",
   :iso_md5 => "03177dfefb4ebfeb03f457c29f00b0a1",

--- a/templates/CentOS-6.1-x86_64-netboot/definition.rb
+++ b/templates/CentOS-6.1-x86_64-netboot/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.1-x86_64-netinstall.iso",
   :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.1/isos/x86_64/CentOS-6.1-x86_64-netinstall.iso",
   :iso_md5 => "b0366858089526fb025f0da4abf6d732",

--- a/templates/CentOS-6.2-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.2-x86_64-minimal/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.2-x86_64-minimal.iso",
   :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.2/isos/x86_64/CentOS-6.2-x86_64-minimal.iso",
   :iso_md5 => "20dac370a6e08ded2701e4104855bc6e",

--- a/templates/CentOS-6.2-x86_64-netboot/definition.rb
+++ b/templates/CentOS-6.2-x86_64-netboot/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.2-x86_64-netinstall.iso",
   :iso_src => "http://mirror.symnds.com/distributions/CentOS-vault/6.2/isos/x86_64/CentOS-6.2-x86_64-netinstall.iso",
   :iso_md5 => "7e7f4161a5c8c49032655e5f4ecd1f07",

--- a/templates/CentOS-6.3-x86_64-netboot/definition.rb
+++ b/templates/CentOS-6.3-x86_64-netboot/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.3-x86_64-netinstall.iso",
   :iso_src => "http://www.mirrorservice.org/sites/mirror.centos.org/6.3/isos/x86_64/CentOS-6.3-x86_64-netinstall.iso",
   :iso_md5 => "690138908de516b6e5d7d180d085c3f3",

--- a/templates/CentOS-6.3-x86_64-reallyminimal/definition.rb
+++ b/templates/CentOS-6.3-x86_64-reallyminimal/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.3-x86_64-minimal.iso",
   :iso_src => "http://www.mirrorservice.org/sites/mirror.centos.org/6.3/isos/x86_64/CentOS-6.3-x86_64-minimal.iso",
   :iso_md5 => "087713752fa88c03a5e8471c661ad1a2",

--- a/templates/CentOS-6.4-x86_64-minimal/definition.rb
+++ b/templates/CentOS-6.4-x86_64-minimal/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.4-x86_64-minimal.iso",
   :iso_src => "http://yum.singlehop.com/CentOS/6.4/isos/x86_64/CentOS-6.4-x86_64-minimal.iso",
   :iso_md5 => "4a5fa01c81cc300f4729136e28ebe600",

--- a/templates/CentOS-6.4-x86_64-netboot/definition.rb
+++ b/templates/CentOS-6.4-x86_64-netboot/definition.rb
@@ -4,7 +4,7 @@ Veewee::Session.declare({
   :disk_size => '10140',
   :disk_format => 'VDI',
   :hostiocache => 'off',
-  :os_type_id => 'RedHat_64',
+  :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-6.4-x86_64-netinstall.iso",
   :iso_src => "http://www.mirrorservice.org/sites/mirror.centos.org/6.4/isos/x86_64/CentOS-6.4-x86_64-netinstall.iso",
   :iso_md5 => "bb9af2aea1344597e11070abe6b1fcd3",


### PR DESCRIPTION
See jedi4ever/veewee#609
This was needed on all but one of the CentOS templates.

The 32bit values while functional, only tell Fusion its a RedHat box not a RedHat 6 box. I can submit a pull request for that if we want to fix it.
