### PR TITLE
Fix "can't convert Net::SSH::AuthenticationFailed into String (TypeError...

### DIFF
--- a/lib/veewee/provider/core/box/exec.rb
+++ b/lib/veewee/provider/core/box/exec.rb
@@ -41,7 +41,7 @@ module Veewee
               end
             rescue Net::SSH::AuthenticationFailed => ex # may want to catch winrm auth fails as well
               env.ui.error "Authentication failure"
-              raise Veewee::SshError, "Authentication failure\n"+ex
+              raise Veewee::SshError, "Authentication failure\n"+ex.inspect
             end
           end
 


### PR DESCRIPTION
...)"

Another minor fix so veewee doesn't error out while trying to raise an error :D
