### PR TITLE
Adds new 'determine_vboxcmd' method.

### DIFF
--- a/lib/veewee/provider/virtualbox/box.rb
+++ b/lib/veewee/provider/virtualbox/box.rb
@@ -22,6 +22,8 @@ require 'veewee/provider/virtualbox/box/helper/buildinfo'
 require 'veewee/provider/virtualbox/box/helper/console_type'
 require 'veewee/provider/virtualbox/box/up'
 
+require 'whichr'
+
 module Veewee
   module Provider
     module Virtualbox
@@ -30,15 +32,27 @@ module Veewee
         include ::Veewee::Provider::Virtualbox::BoxCommand
 
         def initialize(name,env)
-
-          #require 'virtualbox'
-          @vboxcmd=determine_vboxcmd
-          super(name,env)
-
+          @vboxcmd = self.class.determine_vboxcmd
+          super(name, env)
         end
 
-        def determine_vboxcmd
-          return "VBoxManage"
+        def self.windows_vboxcmd
+          # based on Vagrant/plugins/providers/virtualbox/driver/base.rb
+          if OS.windows? && ENV.has_key?("VBOX_INSTALL_PATH")
+            ENV["VBOX_INSTALL_PATH"].split(File::PATH_SEPARATOR).each do |path|
+              vboxmanage = File.join(path,"VBoxManage.exe")
+              return "\"#{vboxmanage}\"" if File.file?(vboxmanage)
+            end
+          end
+          nil
+        end
+
+        def self.default_vboxcmd
+          "VBoxManage"
+        end
+
+        def self.determine_vboxcmd
+          @command ||= windows_vboxcmd || default_vboxcmd
         end
 
 

--- a/lib/veewee/provider/virtualbox/provider.rb
+++ b/lib/veewee/provider/virtualbox/provider.rb
@@ -1,4 +1,5 @@
 require 'veewee/provider/core/provider'
+require 'veewee/provider/virtualbox/box'
 
 module Veewee
   module Provider
@@ -8,7 +9,8 @@ module Veewee
 #        include ::Veewee::Provider::Virtualbox::ProviderCommand
 
         def check_requirements
-          unless self.shell_exec("VBoxManage -v").status == 0
+          command = Box.determine_vboxcmd
+          unless self.shell_exec("#{command} -v").status == 0
             raise Veewee::Error,"Could not execute VBoxManage command. Please install Virtualbox or make sure VBoxManage is in the Path"
           end
         end

--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "childprocess"
   s.add_dependency "grit"
   s.add_dependency "fission", "0.4.0"
+  s.add_dependency "whichr"
 
   # Modified dependency version, as libxml-ruby dependency has been removed in version 2.1.1
   # See : https://github.com/ckruse/CFPropertyList/issues/14


### PR DESCRIPTION
Veewee couldn't locate VBoxManage command on Windows because it is not in the PATH.
