### PR TITLE
fix fedora19 chef rubygems issue

### DIFF
--- a/templates/Fedora-19-i386/chef.sh
+++ b/templates/Fedora-19-i386/chef.sh
@@ -12,6 +12,9 @@ yum -y install \
   rubygem-treetop \
   rubygem-uuidtools
 
+# chef 11.4.4 requires rubygems/format which is ruby 1.9 specific and fedora 19 comes with ruby 2.0
+touch /usr/share/rubygems/rubygems/format.rb
+
 # Install Chef
 gem install --no-ri --no-rdoc chef
 

--- a/templates/Fedora-19-x86_64/chef.sh
+++ b/templates/Fedora-19-x86_64/chef.sh
@@ -12,6 +12,9 @@ yum -y install \
   rubygem-treetop \
   rubygem-uuidtools
 
+# chef 11.4.4 requires rubygems/format which is ruby 1.9 specific and fedora 19 comes with ruby 2.0
+touch /usr/share/rubygems/rubygems/format.rb
+
 # Install Chef
 gem install --no-ri --no-rdoc chef
 


### PR DESCRIPTION
fixes:

``` bash
$ veewee vbox validate fedora-19-x86_64
...
Checking chef - FAILED
Command: . /etc/profile ;chef-client --version 2> /dev/null 1>/dev/null; echo $?
Expected string 0
Output: 
```

=>

``` bash
$ chef-client --version
/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require': cannot load such file -- rubygems/format (LoadError)
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/local/share/gems/gems/chef-11.4.4/lib/chef/provider/package/rubygems.rb:34:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/local/share/gems/gems/chef-11.4.4/lib/chef/providers.rb:60:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/local/share/gems/gems/chef-11.4.4/lib/chef.rb:25:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/local/share/gems/gems/chef-11.4.4/bin/chef-client:23:in `<top (required)>'
    from /usr/local/bin/chef-client:23:in `load'
    from /usr/local/bin/chef-client:23:in `<main>'
```
