### PR TITLE
Remove hardcoded references to /dev/sda

### DIFF
--- a/templates/CentOS-4.8-i386/ks.cfg
+++ b/templates/CentOS-4.8-i386/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.5-i386-netboot/ks.cfg
+++ b/templates/CentOS-5.5-i386-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.5-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-5.5-x86_64-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.6-i386-netboot/ks.cfg
+++ b/templates/CentOS-5.6-i386-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.6-i386/ks.cfg
+++ b/templates/CentOS-5.6-i386/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.6-x86_64-netboot-packages/ks.cfg
+++ b/templates/CentOS-5.6-x86_64-netboot-packages/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.6-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-5.6-x86_64-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.7-i386-netboot/ks.cfg
+++ b/templates/CentOS-5.7-i386-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.7-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-5.7-x86_64-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.8-i386-netboot/ks.cfg
+++ b/templates/CentOS-5.8-i386-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.8-i386/ks.cfg
+++ b/templates/CentOS-5.8-i386/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.8-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-5.8-x86_64-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.8-x86_64-reallyminimal/ks.cfg
+++ b/templates/CentOS-5.8-x86_64-reallyminimal/ks.cfg
@@ -26,9 +26,9 @@ reboot
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
 zerombr
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.8-x86_64/ks.cfg
+++ b/templates/CentOS-5.8-x86_64/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.9-i386-netboot/ks.cfg
+++ b/templates/CentOS-5.9-i386-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.9-i386/ks.cfg
+++ b/templates/CentOS-5.9-i386/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.9-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-5.9-x86_64-netboot/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-5.9-x86_64/ks.cfg
+++ b/templates/CentOS-5.9-x86_64/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=sda
-part pv.2 --size=0 --grow --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/templates/CentOS-6.3-x86_64-reallyminimal/ks.cfg
+++ b/templates/CentOS-6.3-x86_64-reallyminimal/ks.cfg
@@ -26,7 +26,7 @@ user --name=vagrant --groups=wheel --password=vagrant
 
 # partitioning
 zerombr
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 autopart
 
 %packages --nobase

--- a/templates/Debian-5.0.10-amd64-netboot/preseed.cfg
+++ b/templates/Debian-5.0.10-amd64-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-5.0.10-i386-netboot/preseed.cfg
+++ b/templates/Debian-5.0.10-i386-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-5.0.8-amd64-netboot/preseed.cfg
+++ b/templates/Debian-5.0.8-amd64-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-5.0.8-i386-netboot/preseed.cfg
+++ b/templates/Debian-5.0.8-i386-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.3-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.3-amd64-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.3-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.3-i386-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.4-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.4-amd64-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.4-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.4-i386-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.5-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.5-amd64-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.5-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.5-i386-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.6-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.6-amd64-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.6-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.6-i386-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.7-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.7-amd64-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-6.0.7-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.7-i386-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-7.0-amd64-netboot/preseed.cfg
+++ b/templates/Debian-7.0-amd64-netboot/preseed.cfg
@@ -94,7 +94,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Debian-7.0-i386-netboot/preseed.cfg
+++ b/templates/Debian-7.0-i386-netboot/preseed.cfg
@@ -96,7 +96,7 @@ d-i clock-setup/ntp boolean true
 # be given in traditional non-devfs format.
 # Note: A disk must be specified, unless the system has only one disk.
 # For example, to use the first SCSI/SATA hard disk:
-d-i partman-auto/disk string /dev/sda
+#d-i partman-auto/disk string /dev/sda
 # In addition, you'll need to specify the method to use.
 # The presently available methods are: "regular", "lvm" and "crypto"
 d-i partman-auto/method string lvm

--- a/templates/Fedora-14-amd64-netboot/ks.cfg
+++ b/templates/Fedora-14-amd64-netboot/ks.cfg
@@ -11,13 +11,13 @@ firewall --enabled --trust eth0 --ssh
 selinux --enforcing
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 timezone --utc America/Los_Angeles
-bootloader --location=mbr --driveorder=sda --append="nomodeset rhgb quiet"
+bootloader --location=mbr --append="nomodeset rhgb quiet"
 # The following is the partition information you requested
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype=ext4 --size=500 --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype=ext4 --size=500
 part pv.2 --size=0 --grow --size=500
 volgroup vg_main --pesize=32768 pv.2
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_main --size=528 --grow --maxsize=1056

--- a/templates/Fedora-14-amd64/ks.cfg
+++ b/templates/Fedora-14-amd64/ks.cfg
@@ -11,13 +11,13 @@ firewall --enabled --trust eth0 --ssh
 selinux --enforcing
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 timezone --utc America/Los_Angeles
-bootloader --location=mbr --driveorder=sda --append="nomodeset rhgb quiet"
+bootloader --location=mbr --append="nomodeset rhgb quiet"
 # The following is the partition information you requested
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype=ext4 --size=500 --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype=ext4 --size=500
 part pv.2 --size=0 --grow --size=500
 volgroup vg_main --pesize=32768 pv.2
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_main --size=528 --grow --maxsize=1056

--- a/templates/Fedora-14-i386-netboot/ks.cfg
+++ b/templates/Fedora-14-i386-netboot/ks.cfg
@@ -11,13 +11,13 @@ firewall --enabled --trust eth0 --ssh
 selinux --enforcing
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 timezone --utc America/Los_Angeles
-bootloader --location=mbr --driveorder=sda --append="nomodeset rhgb quiet"
+bootloader --location=mbr --append="nomodeset rhgb quiet"
 # The following is the partition information you requested
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype=ext4 --size=500 --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype=ext4 --size=500
 part pv.2 --size=0 --grow --size=500
 volgroup vg_main --pesize=32768 pv.2
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_main --size=528 --grow --maxsize=1056

--- a/templates/Fedora-14-i386/ks.cfg
+++ b/templates/Fedora-14-i386/ks.cfg
@@ -11,13 +11,13 @@ firewall --enabled --trust eth0 --ssh
 selinux --enforcing
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 timezone --utc America/Los_Angeles
-bootloader --location=mbr --driveorder=sda --append="nomodeset rhgb quiet"
+bootloader --location=mbr --append="nomodeset rhgb quiet"
 # The following is the partition information you requested
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
-part /boot --fstype=ext4 --size=500 --ondisk=sda
+clearpart --all --initlabel
+part /boot --fstype=ext4 --size=500
 part pv.2 --size=0 --grow --size=500
 volgroup vg_main --pesize=32768 pv.2
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_main --size=528 --grow --maxsize=1056

--- a/templates/Fedora-15-i386-netboot/ks.cfg
+++ b/templates/Fedora-15-i386-netboot/ks.cfg
@@ -14,7 +14,7 @@ firewall --service=ssh
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 part /boot --fstype=ext4 --size=500
 part pv.2 --grow --size=500
@@ -22,7 +22,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb"
+bootloader --location=mbr --append="norhgb"
 repo --name="Fedora 15 - i386"  --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-15&arch=i386 --cost=1000
 repo --name="Fedora 15 - i386 - Updates"  --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f15&arch=i386 --cost=1000
 services --enabled network

--- a/templates/Fedora-15-i386/ks.cfg
+++ b/templates/Fedora-15-i386/ks.cfg
@@ -14,7 +14,7 @@ firewall --service=ssh
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 part /boot --fstype=ext4 --size=500
 part pv.2 --grow --size=500
@@ -22,7 +22,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb"
+bootloader --location=mbr --append="norhgb"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 15 - i386" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-15&arch=i386 --cost=1000
 #repo --name="Fedora 15 - i386 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f15&arch=i386 --cost=1000

--- a/templates/Fedora-15-x86_64-netboot/ks.cfg
+++ b/templates/Fedora-15-x86_64-netboot/ks.cfg
@@ -14,7 +14,7 @@ firewall --service=ssh
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 part /boot --fstype=ext4 --size=500
 part pv.2 --grow --size=500
@@ -22,7 +22,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb"
+bootloader --location=mbr --append="norhgb"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 15 - x86_64" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-15&arch=x86_64 --cost=1000
 #repo --name="Fedora 15 - x86_64 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f15&arch=x86_64 --cost=1000

--- a/templates/Fedora-15-x86_64/ks.cfg
+++ b/templates/Fedora-15-x86_64/ks.cfg
@@ -14,7 +14,7 @@ firewall --service=ssh
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 part /boot --fstype=ext4 --size=500
 part pv.2 --grow --size=500
@@ -22,7 +22,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb"
+bootloader --location=mbr --append="norhgb"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 15 - x86_64" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-15&arch=x86_64 --cost=1000
 #repo --name="Fedora 15 - x86_64 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f15&arch=x86_64 --cost=1000

--- a/templates/Fedora-16-i386/ks.cfg
+++ b/templates/Fedora-16-i386/ks.cfg
@@ -16,7 +16,7 @@ firewall --service=ssh
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 part biosboot --fstype=biosboot --size=1
 part /boot --fstype=ext4 --size=500
@@ -25,7 +25,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb biosdevname=0"
+bootloader --location=mbr --append="norhgb biosdevname=0"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 16 - i386" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-16&arch=i386 --cost=1000
 #repo --name="Fedora 16 - i386 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f16&arch=i386 --cost=1000

--- a/templates/Fedora-16-x86_64-netboot/ks.cfg
+++ b/templates/Fedora-16-x86_64-netboot/ks.cfg
@@ -14,7 +14,7 @@ firewall --service=ssh
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 part biosboot --fstype=biosboot --size=1
 part /boot --fstype=ext4 --size=500
@@ -23,7 +23,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb biosdevname=0"
+bootloader --location=mbr --append="norhgb biosdevname=0"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 16 - x86_64" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-16&arch=x86_64 --cost=1000
 #repo --name="Fedora 16 - x86_64 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f16&arch=x86_64 --cost=1000

--- a/templates/Fedora-16-x86_64/ks.cfg
+++ b/templates/Fedora-16-x86_64/ks.cfg
@@ -16,7 +16,7 @@ firewall --service=ssh
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 part biosboot --fstype=biosboot --size=1
 part /boot --fstype=ext4 --size=500
@@ -25,7 +25,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb biosdevname=0"
+bootloader --location=mbr --append="norhgb biosdevname=0"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 16 - x86_64" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-16&arch=x86_64 --cost=1000
 #repo --name="Fedora 16 - x86_64 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f16&arch=x86_64 --cost=1000

--- a/templates/Fedora-17-i386/ks.cfg
+++ b/templates/Fedora-17-i386/ks.cfg
@@ -20,7 +20,7 @@ zerombr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 part biosboot --fstype=biosboot --size=1
 part /boot --fstype=ext4 --size=500
@@ -29,7 +29,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb biosdevname=0"
+bootloader --location=mbr --append="norhgb biosdevname=0"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 16 - i386" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-16&arch=i386 --cost=1000
 #repo --name="Fedora 16 - i386 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f16&arch=i386 --cost=1000

--- a/templates/Fedora-17-x86_64/ks.cfg
+++ b/templates/Fedora-17-x86_64/ks.cfg
@@ -20,7 +20,7 @@ zerombr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 #part biosboot --fstype=biosboot --size=1
 part /boot --fstype=ext4 --size=500
@@ -29,7 +29,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb biosdevname=0"
+bootloader --location=mbr --append="norhgb biosdevname=0"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 17 - x86_64" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-17&arch=x86_64 --cost=1000
 #repo --name="Fedora 17 - x86_64 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f17&arch=x86_64 --cost=1000

--- a/templates/Fedora-18-i386/ks.cfg
+++ b/templates/Fedora-18-i386/ks.cfg
@@ -20,7 +20,7 @@ zerombr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 #part biosboot --fstype=biosboot --size=1
 part /boot --fstype=ext4 --size=500
@@ -29,7 +29,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb biosdevname=0"
+bootloader --location=mbr --append="norhgb biosdevname=0"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 17 - x86_64" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-17&arch=x86_64 --cost=1000
 #repo --name="Fedora 17 - x86_64 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f17&arch=x86_64 --cost=1000

--- a/templates/Fedora-18-x86_64/ks.cfg
+++ b/templates/Fedora-18-x86_64/ks.cfg
@@ -20,7 +20,7 @@ zerombr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 #part biosboot --fstype=biosboot --size=1
 part /boot --fstype=ext4 --size=500
@@ -29,7 +29,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb biosdevname=0"
+bootloader --location=mbr --append="norhgb biosdevname=0"
 # Disable remote repositories, as this is a non-netinst install.
 #repo --name="Fedora 17 - x86_64" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-17&arch=x86_64 --cost=1000
 #repo --name="Fedora 17 - x86_64 - Updates" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f17&arch=x86_64 --cost=1000

--- a/templates/Fedora-19-i386/ks.cfg
+++ b/templates/Fedora-19-i386/ks.cfg
@@ -20,7 +20,7 @@ zerombr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 #part biosboot --fstype=biosboot --size=1
 part /boot --fstype=ext4 --size=500
@@ -29,7 +29,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb biosdevname=0"
+bootloader --location=mbr --append="norhgb biosdevname=0"
 services --enabled network
 reboot
 

--- a/templates/Fedora-19-x86_64/ks.cfg
+++ b/templates/Fedora-19-x86_64/ks.cfg
@@ -20,7 +20,7 @@ zerombr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=sda --initlabel
+clearpart --all --initlabel
 
 #part biosboot --fstype=biosboot --size=1
 part /boot --fstype=ext4 --size=500
@@ -29,7 +29,7 @@ part pv.2 --grow --size=500
 volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --driveorder=sda --append="norhgb biosdevname=0"
+bootloader --location=mbr --append="norhgb biosdevname=0"
 services --enabled network
 reboot
 


### PR DESCRIPTION
In order to make these templates compatible with virtio disks under KVM, which live at /dev/vda (or indeed others).  The CentOS 6.x templates already do this.

Tested a few and it worked as expected: Debian 5, Debian 7, CentOS 5.5, Fedora 18.
