### PR TITLE
Add rsync to all Debian templates, required for vagrant-libvirt

### DIFF
--- a/templates/Debian-5.0.10-amd64-netboot/preseed.cfg
+++ b/templates/Debian-5.0.10-amd64-netboot/preseed.cfg
@@ -224,7 +224,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-5.0.10-i386-netboot/preseed.cfg
+++ b/templates/Debian-5.0.10-i386-netboot/preseed.cfg
@@ -224,7 +224,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-5.0.8-amd64-netboot/preseed.cfg
+++ b/templates/Debian-5.0.8-amd64-netboot/preseed.cfg
@@ -224,7 +224,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-5.0.8-i386-netboot/preseed.cfg
+++ b/templates/Debian-5.0.8-i386-netboot/preseed.cfg
@@ -224,7 +224,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.3-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.3-amd64-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.3-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.3-i386-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 
+d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.4-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.4-amd64-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.4-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.4-i386-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 
+d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.5-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.5-amd64-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.5-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.5-i386-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 
+d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.6-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.6-amd64-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.6-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.6-i386-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 
+d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.7-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.7-amd64-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-6.0.7-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.7-i386-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 
+d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-7.0-amd64-netboot/preseed.cfg
+++ b/templates/Debian-7.0-amd64-netboot/preseed.cfg
@@ -220,7 +220,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 
+d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/templates/Debian-7.0-i386-netboot/preseed.cfg
+++ b/templates/Debian-7.0-i386-netboot/preseed.cfg
@@ -222,7 +222,7 @@ tasksel tasksel/first multiselect standard
 #tasksel tasksel/desktop multiselect kde, xfce
 
 # Individual additional packages to install
-d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2
+d-i pkgsel/include string openssh-server ntp acpid  sudo bzip2 rsync
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade


### PR DESCRIPTION
plus vagrant-rackspace, vagrant-ovirt and probably others

Tested Debian 5, 6 and 7.
