### PR TITLE
Fix ESXi shutdown command

### DIFF
--- a/templates/VMware-ESXi-5.0u2-x86_64/definition.rb
+++ b/templates/VMware-ESXi-5.0u2-x86_64/definition.rb
@@ -20,7 +20,7 @@ Veewee::Session.declare({
     :ssh_login_timeout => "10000000", :ssh_user => "root", :ssh_password => "vagrant", :ssh_key => "",
     :ssh_host_port => "7222", :ssh_guest_port => "22",
     :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
-    :shutdown_cmd => "/bin/halt",
+    :shutdown_cmd => "poweroff",
     :postinstall_files => ["vagrant_key.py", "vnc_enable.sh" ], :postinstall_timeout => 10000,
     :vmfusion => { :vm_options => { 'enable_hypervisor_support' => true,  'download_tools' => false } }
 })

--- a/templates/VMware-ESXi-5.1-x86_64/definition.rb
+++ b/templates/VMware-ESXi-5.1-x86_64/definition.rb
@@ -20,7 +20,7 @@ Veewee::Session.declare({
     :ssh_login_timeout => "10000000", :ssh_user => "root", :ssh_password => "vagrant", :ssh_key => "",
     :ssh_host_port => "7222", :ssh_guest_port => "22",
     :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
-    :shutdown_cmd => "/bin/halt",
+    :shutdown_cmd => "poweroff",
     :postinstall_files => ["vagrant_key.py", "vnc_enable.sh" ], :postinstall_timeout => 10000,
     # Enable Hypervisor support to allow 64-bit guest VMs
     :vmfusion => { :vm_options => { 'enable_hypervisor_support' => true,  'download_tools' => false } }


### PR DESCRIPTION
Recent testing has shown the original shutdown command `/bin/halt` was incorrect, and `poweroff` is the appropriate command per http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1013193.
