### PR TITLE
Added .project to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ virtualfloppy.vfd
 *.swp
 AutoPartition.app
 .rbenv-gemsets
+.project


### PR DESCRIPTION
After creating an Eclipse project, .project file should not go into Git.
