### PR TITLE
Fixed doc/requirements.md to include PowerShell and PowerShell Community...

### DIFF
--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -34,6 +34,8 @@ On Windows, you will need to install:
 
 * Ruby devkit
 * msysgit
+* PowerShell (if on XP or Vista)
+* PowerShell Community Extensions
 * And you may need to add VirtualBox to your `PATH`, usually installed to `C:\Program Files\Oracle\VirtualBox`.
 
 


### PR DESCRIPTION
... Extensions under Windows

1) Fixed doc/requirements.md to include installing PowerShell and the PowerShell
   Community Extensions (PSCX) under Windows. PSCX supplies several necessary
   cmdlets including Write-Tar.
