### PR TITLE
downgrade rubygems version to 1.8.25

### DIFF
--- a/templates/ubuntu-13.04-server-amd64/ruby.sh
+++ b/templates/ubuntu-13.04-server-amd64/ruby.sh
@@ -13,7 +13,7 @@ cd ..
 rm -rf ruby-$RUBY_VERSION
 rm ruby-$RUBY_VERSION.tar.gz
 
-RUBYGEMS_VERSION=2.0.3
+RUBYGEMS_VERSION=1.8.25
 wget http://production.cf.rubygems.org/rubygems/rubygems-$RUBYGEMS_VERSION.tgz
 tar xzf rubygems-$RUBYGEMS_VERSION.tgz
 cd rubygems-$RUBYGEMS_VERSION
@@ -22,4 +22,4 @@ cd ..
 rm -rf rubygems-$RUBYGEMS_VERSION
 rm rubygems-$RUBYGEMS_VERSION.tgz
 
-echo 'PATH=$PATH:/opt/ruby/bin/' > /etc/profile.d/vagrantruby.sh
+echo 'PATH=$PATH:/opt/ruby/bin' > /etc/profile.d/vagrantruby.sh


### PR DESCRIPTION
I've encountered problems using Rubygems 2.0.x in some of my projects. Downgrading did the trick (at least for me).
