### PR TITLE
Pass in URL path to use when calling wait_for_http_request or allow_for_http_request

### DIFF
--- a/lib/veewee/provider/core/box/build.rb
+++ b/lib/veewee/provider/core/box/build.rb
@@ -1,3 +1,5 @@
+require 'to_slug'
+
 module Veewee
   module Provider
     module Core
@@ -218,12 +220,15 @@ module Veewee
           # For each kickstart file spinup a webserver and wait for the file to be fetched
           unless kickstartfiles.nil?
             kickstartfiles.each do |kickfile|
-              wait_for_http_request(kickfile,{
-                :port => definition.kickstart_port,
-                :host => definition.kickstart_ip,
-                :timeout => definition.kickstart_timeout,
-                :web_dir => definition.path
-              })
+              wait_for_http_request(
+                File.join(definition.path, kickfile),
+                kickfile.start_with?('/') ? kickfile : '/' + kickfile,
+                {
+                  :port => definition.kickstart_port,
+                  :host => definition.kickstart_ip,
+                  :timeout => definition.kickstart_timeout,
+                }
+              )
             end
           end
         end

--- a/lib/veewee/provider/core/helper/web.rb
+++ b/lib/veewee/provider/core/helper/web.rb
@@ -3,12 +3,12 @@ module Veewee
     module Core
       module Helper
         require 'webrick'
+
         include WEBrick
+
         module Servlet
 
-
           class FileServlet < WEBrick::HTTPServlet::AbstractServlet
-
             attr_reader :ui, :threaded
 
             def initialize(server,localfile,ui,threaded)
@@ -37,45 +37,44 @@ module Veewee
               end
             end
           end
-
         end
-        module Web
 
-          def wait_for_http_request(filename,options) # original blocking
-            s = server_for_http_request(filename,options)
+        module Web
+          def wait_for_http_request(filename, urlname, options) # original blocking
+            s = server_for_http_request(filename, urlname, options)
             s.start
           end
 
-          def allow_for_http_request(filename,options) # start in new thread
-            s = server_for_http_request(filename,options.merge({:threaded => false}))
+          def allow_for_http_request(filename, urlname, options) # start in new thread
+            s = server_for_http_request(filename, urlname, options.merge({:threaded => false}))
             Thread.new { s.start }
           end
 
-          def server_for_http_request(filename,options={:timeout => 10, :web_dir => "", :port => 7125, :threaded => false})
+          def server_for_http_request(filename, urlname, options={:timeout => 10, :port => 7125, :threaded => false})
             # Calculate the OS equivalent of /dev/null , on windows this is NUL:
             # http://www.ruby-forum.com/topic/115472
             fn = test(?e, '/dev/null') ? '/dev/null' : 'NUL:'
 
             webrick_logger=WEBrick::Log.new(fn, WEBrick::Log::INFO)
 
-            web_dir=options[:web_dir]
-            filename=filename
             s= ::WEBrick::HTTPServer.new(
               :Port => options[:port],
               :Logger => webrick_logger,
               :AccessLog => webrick_logger
             )
-            mount_filename = filename.start_with?('/') ? filename : "/#{filename}"
-            env.logger.debug("mounting file #{mount_filename}")
-            s.mount("#{mount_filename}", Veewee::Provider::Core::Helper::Servlet::FileServlet,File.join(web_dir,filename),ui,options[:threaded])
+
+            env.logger.debug("mounting file #{urlname}")
+
+            s.mount("#{urlname}", Veewee::Provider::Core::Helper::Servlet::FileServlet, filename, ui, options[:threaded])
+
             trap("INT"){
               s.shutdown
               ui.info "Stopping webserver"
               exit
             }
+
             s
           end
-
         end #Class
       end #Module
     end #Module

--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "grit"
   s.add_dependency "fission", "0.4.0"
   s.add_dependency "whichr"
+  s.add_dependency "to_slug"
 
   # Modified dependency version, as libxml-ruby dependency has been removed in version 2.1.1
   # See : https://github.com/ckruse/CFPropertyList/issues/14


### PR DESCRIPTION
Previously, the URL path to expose on the Webrick server as the endpoint was the same as the local file path.  This caused problems in the Windows side where the file path was something like "D:\dirname\file.cfg" because it contains invalid characters for a URL.  

The change here changes the above two methods to explicitly take in a URL path to use as the endpoint.  The calling code uses the "to_slug" gem to clean up invalid characters when generating the URL prior to passing it to the above two functions.
