### PR TITLE
Add SUNWgccruntime to Solaris 10 builds

### DIFF
--- a/templates/solaris-10-ga-x86/jumpstart/profile
+++ b/templates/solaris-10-ga-x86/jumpstart/profile
@@ -29,6 +29,7 @@ package      SUNWsfwhea add
 package      SUNWhea add
 package      SUNWtoo add
 package      SUNWlibm add
+package      SUNWgccruntime add
 
 # BSD compatibility
 package      SUNWscpu add


### PR DESCRIPTION
This package supports 3rd-party binaries built with the Sun/Oracle version of
GCC. Increase in exported VM size is negligible.
