### PR TITLE
Export templates and optimize before export. GH-800

### DIFF
--- a/lib/veewee/command/parallels.rb
+++ b/lib/veewee/command/parallels.rb
@@ -20,7 +20,6 @@ module Veewee
       desc "export [BOX_NAME]", "Exports the basebox to the vagrant-parallels format"
       method_option :debug,:type => :boolean , :default => false, :aliases => "-d", :desc => "enable debugging"
       method_option :force,:type => :boolean , :default => false, :aliases => "-f", :desc => "overwrite existing file"
-      # TODO: Is there a way to reduce Parallels image size?
       method_option :vagrantfile,:type => :string , :default => "", :desc => "specify Vagrantfile"
       def export(box_name)
         env.get_box(box_name).export_vagrant(options)


### PR DESCRIPTION
Now the templates import properly into vagrant-parallels.

Also added disk optimizing, inspired by how VMWare Fusion does it, but simpler. Parallels has pretty decent command-line tools.

@yshahin @legal90 We can use similar logic to implement `vagrant package` in the plugin when the time comes.
