### PR TITLE
Fixes for FreeBSD 9.1 template files.

### DIFF
--- a/templates/freebsd-9.1-RELEASE-amd64/definition.rb
+++ b/templates/freebsd-9.1-RELEASE-amd64/definition.rb
@@ -26,7 +26,7 @@ Veewee::Definition.declare({
   :ssh_login_timeout => "10000", :ssh_user => "vagrant", :ssh_password => "vagrant", :ssh_key => "",
   :ssh_host_port => "7222", :ssh_guest_port => "22",
   :sudo_cmd => "cat '%f' | su -",
-  :shutdown_cmd => "shutdown -h now",
-  :postinstall_files => [ "postinstall.sh"], :postinstall_timeout => "10000"
+  :shutdown_cmd => "shutdown -p now",
+  :postinstall_files => [ "postinstall.csh"], :postinstall_timeout => "10000"
 })
-#'setkmap=us dodhcp=eth0 dhcphostname=%NAME% ar_source=http://%IP%:%PORT%/ autoruns=0 rootpass=vagrant',
+#'setkmap=us dodhcp=em0 dhcphostname=%NAME% ar_source=http://%IP%:%PORT%/ autoruns=0 rootpass=vagrant',


### PR DESCRIPTION
Tweaks to definition.rb to use correct shutdown command.

postinstall.sh -> postinstall.csh since it's really going to be run by csh. Fixes in the file to ensure "fetch" command is used correctly. Also added virtio kmod build so that virtualbox virtio network interface can be used.

Tested with VirtualBox on Mac OS X 10.8.5

Vagrantfile used:

``` rb
# -*- mode: ruby -*-
# vi: set ft=ruby :
VAGRANTFILE_API_VERSION = "2"

Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.guest = :freebsd
  config.vm.box = "freebsd-9.1"
  config.vm.hostname = "FREEBSD-91"
  config.vm.synced_folder(".", "/vagrant", :nfs => true, id: "vagrant-root")
  config.vm.network(:private_network, :ip => "10.0.3.2")
  config.vm.provider :virtualbox do |vb|
    vb.gui = true # for debugging
    vb.customize ["modifyvm", :id, "--memory", "1024"]
    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
    vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
    vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
    vb.customize ["modifyvm", :id, "--audio", "none"]
  end
end
```
