### PR TITLE
replace dead Arch mirror with kernel.org

### DIFF
--- a/templates/archlinux-x86_64/definition.rb
+++ b/templates/archlinux-x86_64/definition.rb
@@ -1,6 +1,6 @@
 require 'net/http'
 
-iso_mirror = 'http://mirror.brainfork.me/archlinux/iso/latest'
+iso_mirror = 'http://mirrors.kernel.org/archlinux/iso/latest'
 uri = "#{iso_mirror}/md5sums.txt"
 response = Net::HTTP.get_response(URI.parse(uri)).body.split
 iso = response[1]


### PR DESCRIPTION
Arch Linux mirror http://mirror.brainfork.me is dead so replaced with available another mirror url
