### PR TITLE
Ubuntu 8.04 needs a preseed.cfg to use http://old-releases.ubuntu.com pa...

### DIFF
--- a/templates/ubuntu-8.04.4-server-amd64/preseed.cfg
+++ b/templates/ubuntu-8.04.4-server-amd64/preseed.cfg
@@ -76,12 +76,12 @@ d-i pkgsel/update-policy select none
 
 # debconf-get-selections --install
 #Use mirror
-#d-i apt-setup/use_mirror boolean true
-#d-i     mirror/country          string manual
-#choose-mirror-bin mirror/protocol	string http
-#choose-mirror-bin mirror/http/hostname	string 192.168.4.150
-#choose-mirror-bin mirror/http/directory	string /ubuntu
-#choose-mirror-bin mirror/suite	select maverick
-#d-i debian-installer/allow_unauthenticated	string true
+d-i apt-setup/use_mirror boolean true
+d-i     mirror/country          string manual
+choose-mirror-bin mirror/protocol	string http
+choose-mirror-bin mirror/http/hostname	string old-releases.ubuntu.com
+choose-mirror-bin mirror/http/directory	string /ubuntu
+choose-mirror-bin mirror/suite	select hardy
+d-i debian-installer/allow_unauthenticated	string true
 
 choose-mirror-bin mirror/http/proxy string

--- a/templates/ubuntu-8.04.4-server-i386/preseed.cfg
+++ b/templates/ubuntu-8.04.4-server-i386/preseed.cfg
@@ -76,12 +76,12 @@ d-i pkgsel/update-policy select none
 
 # debconf-get-selections --install
 #Use mirror
-#d-i apt-setup/use_mirror boolean true
-#d-i     mirror/country          string manual
-#choose-mirror-bin mirror/protocol	string http
-#choose-mirror-bin mirror/http/hostname	string 192.168.4.150
-#choose-mirror-bin mirror/http/directory	string /ubuntu
-#choose-mirror-bin mirror/suite	select maverick
-#d-i debian-installer/allow_unauthenticated	string true
+d-i apt-setup/use_mirror boolean true
+d-i     mirror/country          string manual
+choose-mirror-bin mirror/protocol	string http
+choose-mirror-bin mirror/http/hostname	string old-releases.ubuntu.com
+choose-mirror-bin mirror/http/directory	string /ubuntu
+choose-mirror-bin mirror/suite	select hardy
+d-i debian-installer/allow_unauthenticated	string true
 
 choose-mirror-bin mirror/http/proxy string


### PR DESCRIPTION
Ubuntu 8.04 needs that preseed.cfg defines http://old-releases.ubuntu.com as mirror repository because archive.ubuntu.com does not contains Hardy.
