### PR TITLE
Template: clean+vanilla Ubuntu 12.04.3 desktop

### DIFF
--- a/templates/ubuntu-12.04.3-desktop-i386/apt.sh
+++ b/templates/ubuntu-12.04.3-desktop-i386/apt.sh
@@ -1,0 +1,8 @@
+apt-get -y update
+apt-get -y upgrade
+apt-get -y install linux-headers-$(uname -r) build-essential
+apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev libyaml-dev
+apt-get -y install ntpdate
+apt-get -y install vim
+apt-get -y install dkms
+apt-get -y install nfs-common

--- a/templates/ubuntu-12.04.3-desktop-i386/build_time.sh
+++ b/templates/ubuntu-12.04.3-desktop-i386/build_time.sh
@@ -1,0 +1,1 @@
+date > /etc/vagrant_box_build_time

--- a/templates/ubuntu-12.04.3-desktop-i386/chef.sh
+++ b/templates/ubuntu-12.04.3-desktop-i386/chef.sh
@@ -1,0 +1,3 @@
+GEM=/opt/ruby/bin/gem
+
+$GEM install chef --no-ri --no-rdoc

--- a/templates/ubuntu-12.04.3-desktop-i386/cleanup.sh
+++ b/templates/ubuntu-12.04.3-desktop-i386/cleanup.sh
@@ -1,0 +1,16 @@
+apt-get -y autoremove
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY
+
+echo "cleaning up dhcp leases"
+rm /var/lib/dhcp/*
+
+echo "cleaning up udev rules"
+rm /etc/udev/rules.d/70-persistent-net.rules
+mkdir /etc/udev/rules.d/70-persistent-net.rules
+rm -rf /dev/.udev/
+rm /lib/udev/rules.d/75-persistent-net-generator.rules
+
+echo "pre-up sleep 2" >> /etc/network/interfaces
+exit

--- a/templates/ubuntu-12.04.3-desktop-i386/definition.rb
+++ b/templates/ubuntu-12.04.3-desktop-i386/definition.rb
@@ -1,0 +1,57 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size => '1900',     # safe for 4GB Machines
+  :video_memory_size => '64', # more is better for VM performance
+  :disk_size => '32000',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'Ubuntu',
+  :iso_file => "ubuntu-12.04.3-alternate-i386.iso",
+  :iso_src => "http://releases.ubuntu.com/12.04/ubuntu-12.04.3-alternate-i386.iso",
+  :iso_md5 => "927f06b00821cb4069ce359fe1ec7edb",
+  :iso_download_timeout => "1000",
+  :boot_wait => "4",
+  :boot_cmd_sequence => [
+    '<Esc><Esc><Enter>',
+    '/install/vmlinuz preseed/url=http://%IP%:%PORT%/preseed.cfg ',
+    'debian-installer=en_US auto locale=en_US kbd-chooser/method=us ',
+    'hostname=%NAME% ',
+    'fb=false debconf/frontend=noninteractive ',
+    'keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=us keyboard-configuration/variant=us console-setup/ask_detect=false ',
+    'initrd=/install/initrd.gz -- <Enter>'
+],
+  :kickstart_port => "7122",
+  :kickstart_timeout => "10000",
+  :kickstart_file => "preseed.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "vagrant",
+  :ssh_password => "vagrant",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "shutdown -P now",
+  :postinstall_files => [
+   "build_time.sh",
+   "apt.sh",
+   "vbox.sh",
+   "sudo.sh",
+   "ruby.sh",
+   "chef.sh",
+   "puppet.sh",
+   "vagrant.sh",
+   "cleanup.sh"
+  ],
+  :postinstall_timeout => "10000",
+  :virtualbox => {
+    :vm_options => [
+        'ioapic' => 'on',               # APIC is necessary for multi processor support
+        'rtcuseutc' => 'on',            # UTC internal time
+        'accelerate3d' => 'on',         # Necessary for X to start the Unity desktop in Ubuntu 12.10+ -- Useful for 12.04, although can slow the VM if host hardware lacks good 3D support
+        'clipboard' => 'bidirectional'  # Useful for clipboard sharing between host & guest
+    # A Full list of settings can be found here: http://virtualbox.org/manual/ch08.html#idp51057568
+    # Or generated based on the current settings of a virtualbox guest, such a machine named: myubuntu
+    # VBoxManage showvminfo --machinereadable 'myubuntu'
+    ]
+  }
+})

--- a/templates/ubuntu-12.04.3-desktop-i386/preseed.cfg
+++ b/templates/ubuntu-12.04.3-desktop-i386/preseed.cfg
@@ -1,0 +1,106 @@
+# Preseed file is used to automate installation
+# Further explantaion, options and examples: https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html
+# More here: https://wiki.debian.org/DebianInstaller/Preseed
+
+### Localization
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-l10n
+#   Preseeding only locale sets language, country and locale.
+d-i debian-installer/locale string en_US.UTF-8
+#   KEYBOARD - architecture and a keymap
+d-i console-setup/ask_detect boolean false
+d-i console-setup/layout string US
+
+### Network configuration
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-network
+#   HOSTNAME - IMPORTANT: don't use '.' (dot) in your veewee definition boxname!!!
+d-i netcfg/get_hostname string unassigned-hostname
+d-i netcfg/get_domain string unassigned-domain
+#   MIRROR
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-network-console
+#   simpler default than above link
+choose-mirror-bin mirror/http/proxy string
+
+### Clock and time zone setup
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-time
+d-i time/zone string UTC
+d-i clock-setup/utc-auto boolean true
+d-i clock-setup/utc boolean true
+
+### Partitioning
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-partman
+d-i partman-auto/method string lvm
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman/confirm_write_new_label boolean true
+d-i partman/confirm_nooverwrite boolean true
+# This makes partman automatically partition without confirmation
+d-i partman-lvm/confirm boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+### Base system installation
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-base-installer
+#   The kernel image (meta) package to be installed; "none" can be used if no
+#   kernel is to be installed.
+#d-i base-installer/kernel/image string linux-generic
+
+### Account setup
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-account
+#   Setup default user
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i user-setup/encrypt-home boolean false
+d-i user-setup/allow-password-weak boolean true
+
+### APT setup
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-apt
+#   You can choose to install restricted and universe software, or to install
+#   software from the backports repository.
+#d-i apt-setup/restricted boolean true
+#d-i apt-setup/universe boolean true
+#d-i apt-setup/backports boolean true
+#   Uncomment this if you don't want to use a network mirror.
+#d-i apt-setup/use_mirror boolean false
+#   Select which update services to use; define the mirrors to be used.
+#   Values shown below are the normal defaults.
+#d-i apt-setup/services-select multiselect security
+#d-i apt-setup/security_host string security.ubuntu.com
+#d-i apt-setup/security_path string /ubuntu
+
+### Package selection
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-pkgsel
+#   Install Ubuntu desktop
+tasksel tasksel/first multiselect ubuntu-desktop
+
+
+#   Individual additional packages to install
+#   Minimum packages for veewee and virtualbox
+d-i pkgsel/include string openssh-server build-essential
+#d-i pkgsel/include string openssh-server build-essential
+#   Whether to upgrade packages after debootstrap.
+#   Allowed values: none, safe-upgrade, full-upgrade
+#d-i pkgsel/upgrade select safe-upgrade
+
+#   No language support packages.
+# @TODO: not positive this is valid for 12.04
+d-i pkgsel/install-language-support boolean false
+
+# Policy for applying updates. May be
+#   "none" (no automatic updates),
+#   "unattended-upgrades" (install security updates automatically), or
+#   "landscape" (manage system with Landscape).
+#d-i pkgsel/update-policy select none
+
+### Boot loader installation
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-bootloader
+d-i grub-installer/only_debian boolean true
+
+### Finishing
+#   https://help.ubuntu.com/lts/installation-guide/i386/preseed-contents.html#preseed-finish
+#   Prevent automatic reboot, so that a veewee script can control this
+d-i finish-install/reboot_in_progress note

--- a/templates/ubuntu-12.04.3-desktop-i386/puppet.sh
+++ b/templates/ubuntu-12.04.3-desktop-i386/puppet.sh
@@ -1,0 +1,4 @@
+GEM=/opt/ruby/bin/gem
+
+adduser --system --group --home /var/lib/puppet puppet
+$GEM install puppet --no-ri --no-rdoc

--- a/templates/ubuntu-12.04.3-desktop-i386/ruby.sh
+++ b/templates/ubuntu-12.04.3-desktop-i386/ruby.sh
@@ -1,0 +1,25 @@
+apt-get -y install libyaml-0-2
+RUBY_VERSION=1.9.3-p392
+
+cd /tmp
+
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-$RUBY_VERSION.tar.gz
+tar xvzf ruby-$RUBY_VERSION.tar.gz
+cd ruby-$RUBY_VERSION
+./configure --prefix=/opt/ruby
+make
+make install
+cd ..
+rm -rf ruby-$RUBY_VERSION
+rm ruby-$RUBY_VERSION.tar.gz
+
+RUBYGEMS_VERSION=2.0.3
+wget http://production.cf.rubygems.org/rubygems/rubygems-$RUBYGEMS_VERSION.tgz
+tar xzf rubygems-$RUBYGEMS_VERSION.tgz
+cd rubygems-$RUBYGEMS_VERSION
+/opt/ruby/bin/ruby setup.rb
+cd ..
+rm -rf rubygems-$RUBYGEMS_VERSION
+rm rubygems-$RUBYGEMS_VERSION.tgz
+
+echo 'PATH=$PATH:/opt/ruby/bin/' > /etc/profile.d/vagrantruby.sh

--- a/templates/ubuntu-12.04.3-desktop-i386/sudo.sh
+++ b/templates/ubuntu-12.04.3-desktop-i386/sudo.sh
@@ -1,0 +1,5 @@
+groupadd -r admin
+usermod -a -G admin vagrant
+cp /etc/sudoers /etc/sudoers.orig
+sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
+sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers

--- a/templates/ubuntu-12.04.3-desktop-i386/vagrant.sh
+++ b/templates/ubuntu-12.04.3-desktop-i386/vagrant.sh
@@ -1,0 +1,6 @@
+mkdir /home/vagrant/.ssh
+chmod 700 /home/vagrant/.ssh
+cd /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
+chmod 600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh

--- a/templates/ubuntu-12.04.3-desktop-i386/vbox.sh
+++ b/templates/ubuntu-12.04.3-desktop-i386/vbox.sh
@@ -1,0 +1,18 @@
+# Without libdbus virtualbox would not start automatically after compile
+apt-get -y install --no-install-recommends libdbus-1-3
+
+# Remove existing VirtualBox guest additions
+/etc/init.d/virtualbox-ose-guest-utils stop
+rmmod vboxguest
+aptitude -y purge virtualbox-ose-guest-x11 virtualbox-ose-guest-dkms virtualbox-ose-guest-utils
+aptitude -y install dkms
+
+# Install the VirtualBox guest additions
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+VBOX_ISO=VBoxGuestAdditions_$VBOX_VERSION.iso
+mount -o loop $VBOX_ISO /mnt
+yes|sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+
+# Cleanup
+rm $VBOX_ISO


### PR DESCRIPTION
New preseed.cfg + sane Vbox default settings + comments in preseed + definition

This template is loosely based on _ubuntu-12.04.3-server-i386_ and  **_ubuntu-12.04.2-desktop-amd64**_
### Main changes
- Reorganize preseed.cfg based on precise example+documentation
- Mess with partitioning and change disk size (smaller) to 30GB  (exports to 1.1GB box)
- Improve VirtualBox default settings for a desktop image and document
- Cleanup cruft
### Settings
-  **Version:**  Ubuntu 12.04.3 Desktop release
-  **Locale:** en_US
-  **Keyboard layout:** US
-  **Timezone:** UTC
-  **Extra Language Support:** none
