### PR TITLE
Need ruby-shadow in order to set user passwords in Puppet

### DIFF
--- a/templates/CentOS-5.9-i386-netboot/puppet.sh
+++ b/templates/CentOS-5.9-i386-netboot/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-5.9-i386/puppet.sh
+++ b/templates/CentOS-5.9-i386/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-5.9-x86_64-netboot/puppet.sh
+++ b/templates/CentOS-5.9-x86_64-netboot/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-5.9-x86_64/puppet.sh
+++ b/templates/CentOS-5.9-x86_64/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.0-i386-netboot/puppet.sh
+++ b/templates/CentOS-6.0-i386-netboot/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.0-i386/puppet.sh
+++ b/templates/CentOS-6.0-i386/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.0-x86_64-minimal/puppet.sh
+++ b/templates/CentOS-6.0-x86_64-minimal/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.0-x86_64-netboot/puppet.sh
+++ b/templates/CentOS-6.0-x86_64-netboot/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.0-x86_64/puppet.sh
+++ b/templates/CentOS-6.0-x86_64/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.1-x86_64-minimal/puppet.sh
+++ b/templates/CentOS-6.1-x86_64-minimal/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.1-x86_64-netboot/puppet.sh
+++ b/templates/CentOS-6.1-x86_64-netboot/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.2-i386-minimal/puppet.sh
+++ b/templates/CentOS-6.2-i386-minimal/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.2-x86_64-minimal/puppet.sh
+++ b/templates/CentOS-6.2-x86_64-minimal/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.2-x86_64-netboot/puppet.sh
+++ b/templates/CentOS-6.2-x86_64-netboot/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.3-i386-minimal/puppet.sh
+++ b/templates/CentOS-6.3-i386-minimal/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.3-x86_64-minimal/puppet.sh
+++ b/templates/CentOS-6.3-x86_64-minimal/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.3-x86_64-netboot/puppet.sh
+++ b/templates/CentOS-6.3-x86_64-netboot/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.4-i386-minimal/puppet.sh
+++ b/templates/CentOS-6.4-i386-minimal/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.4-i386-netboot/puppet.sh
+++ b/templates/CentOS-6.4-i386-netboot/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.4-x86_64-minimal/puppet.sh
+++ b/templates/CentOS-6.4-x86_64-minimal/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 

--- a/templates/CentOS-6.4-x86_64-netboot/puppet.sh
+++ b/templates/CentOS-6.4-x86_64-netboot/puppet.sh
@@ -14,5 +14,5 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install puppet facter
+yum -y install puppet facter ruby-shadow
 


### PR DESCRIPTION
Without ruby-shadow, Puppet will fail to set user passwords and emit the following message:

```
info: /User[mcfakey]: Provider useradd does not support features manages_passwords; not managing attribute password
```

See http://www.puppetcookbook.com/posts/managing-user-password-fails.html for more information.
