### PR TITLE
Fixed puppet being uninstalled on cleanup

### DIFF
--- a/templates/CentOS-5.9-i386-netboot/cleanup.sh
+++ b/templates/CentOS-5.9-i386-netboot/cleanup.sh
@@ -1,4 +1,4 @@
-yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y erase gtk2 hicolor-icon-theme avahi freetype bitstream-vera-fonts
 yum -y clean all
 rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
 rm -rf VBoxGuestAdditions_*.iso

--- a/templates/CentOS-5.9-i386/cleanup.sh
+++ b/templates/CentOS-5.9-i386/cleanup.sh
@@ -1,4 +1,4 @@
-yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y erase gtk2 hicolor-icon-theme avahi freetype bitstream-vera-fonts
 yum -y clean all
 rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
 rm -rf VBoxGuestAdditions_*.iso


### PR DESCRIPTION
When libX11 is uninstalled on cleanup, it takes Puppet with it.  Not very useful if you want to use Puppet with your base base box.
