### PR TITLE
Add ruby to Support to arch x64 as Chef supports ruby 2.0 now

### DIFF
--- a/templates/archlinux-x86_64/chef.sh
+++ b/templates/archlinux-x86_64/chef.sh
@@ -4,17 +4,6 @@
 #   ruby.sh
 #   aur.sh
 
-# Don't install ruby-highline from Arch repositories since it was built against
-# Ruby 2.0. Build from source. Remove this section when Chef supports Ruby 2.0.
-mkdir -p /tmp/ruby-highline
-wget 'https://projects.archlinux.org/svntogit/community.git/plain/trunk/PKGBUILD?h=packages/ruby-highline&id=49e00a9ea7ffa267048aa7fc7a82a0427c10958d' \
-  -O /tmp/ruby-highline/PKGBUILD
-chown -R veewee:veewee /tmp/ruby-highline
-cd /tmp/ruby-highline
-su veewee -c 'makepkg -si --noconfirm'
-cd -
-rm -rf /tmp/ruby-highline
-
 # Change TMPDIR for packer to stop /tmp from filling up during install
 export TMPDIR=$(pwd)/tmp
 mkdir -p $TMPDIR

--- a/templates/archlinux-x86_64/ruby.sh
+++ b/templates/archlinux-x86_64/ruby.sh
@@ -3,22 +3,7 @@
 # Requires
 #   reboot.sh
 
-# Uncomment this and delete the Ruby 1.9 install section below when Chef
-# supports Ruby 2.0
-#pacman -S --noconfirm ruby
-
-# We can install Ruby 1.9 either using an older PKGBUILD or download the
-# package from the Arch Rollback Machine. Using the Rollback Machine saves from
-# having to compile Ruby for every new VM.
-arch="$(uname -m)"
-package="ruby-1.9.3_p392-1-${arch}.pkg.tar.xz"
-
-cd /tmp
-wget "http://arm.konnichi.com/2013/03/23/extra/os/${arch}/${package}"
-pacman -U --noconfirm "${package}"
-
-# Add ruby to Pacman's ignore list so it does not get upgraded to 2.0
-sed -ri 's/^#?(IgnorePkg.*)/\1 ruby/' /etc/pacman.conf
+pacman -S --noconfirm ruby
 
 # Don't install RDoc and RI to save time and space
 cat <<EOF >> /etc/gemrc


### PR DESCRIPTION
Chef supports officially ruby 2.0 since chef 10.28.0:
    http://www.opscode.com/blog/2013/09/03/chef-10-28-0-released/

Currently aur provides chef 11.6.2-2
