### PR TITLE
Use curl -o instead of wget in Arch x64

### DIFF
--- a/templates/archlinux-x86_64/aur.sh
+++ b/templates/archlinux-x86_64/aur.sh
@@ -4,10 +4,8 @@
 #   basedevel.sh
 #   user.sh
 
-pacman -S --noconfirm wget
-
 cd /tmp
-wget 'https://aur.archlinux.org/packages/pa/packer/packer.tar.gz'
+curl 'https://aur.archlinux.org/packages/pa/packer/packer.tar.gz' -o packer.tar.gz
 tar xzf packer.tar.gz
 
 # makepkg should not be run as root

--- a/templates/archlinux-x86_64/ruby.sh
+++ b/templates/archlinux-x86_64/ruby.sh
@@ -14,7 +14,7 @@ arch="$(uname -m)"
 package="ruby-1.9.3_p392-1-${arch}.pkg.tar.xz"
 
 cd /tmp
-wget "http://arm.konnichi.com/2013/03/23/extra/os/${arch}/${package}"
+curl "http://arm.konnichi.com/2013/03/23/extra/os/${arch}/${package}" -o "${package}"
 pacman -U --noconfirm "${package}"
 
 # Add ruby to Pacman's ignore list so it does not get upgraded to 2.0

--- a/templates/archlinux-x86_64/vagrant.sh
+++ b/templates/archlinux-x86_64/vagrant.sh
@@ -18,10 +18,8 @@ EOF
 # Install the "insecure" public key
 mkdir -m 700 /home/vagrant/.ssh
 
-pacman -S --noconfirm wget
-wget --no-check-certificate \
-  'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' \
-  -O /home/vagrant/.ssh/authorized_keys
+curl 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' \
+  -o /home/vagrant/.ssh/authorized_keys
 
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant:vagrant /home/vagrant/.ssh


### PR DESCRIPTION
wget is yet another dependency we don't necessarily need, use the already provided curl instead

It may conflict with #843 in which case, don't apply the changes on ruby.sh
