### PR TITLE
Remove basedevel step from Arch x64

### DIFF
--- a/templates/archlinux-x86_64/aur.sh
+++ b/templates/archlinux-x86_64/aur.sh
@@ -5,6 +5,7 @@
 #   user.sh
 
 pacman -S --noconfirm wget
+pacman -S --noconfirm base-devel
 
 cd /tmp
 wget 'https://aur.archlinux.org/packages/pa/packer/packer.tar.gz'

--- a/templates/archlinux-x86_64/basedevel.sh
+++ b/templates/archlinux-x86_64/basedevel.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Requires
-#   reboot.sh
-
-pacman -S --noconfirm base-devel

--- a/templates/archlinux-x86_64/definition.rb
+++ b/templates/archlinux-x86_64/definition.rb
@@ -43,7 +43,6 @@ Veewee::Definition.declare({
     'bootloader.sh',
     'ssh.sh',
     'reboot.sh',
-    'basedevel.sh',
     'sudo.sh',
     'user.sh',
     'aur.sh',


### PR DESCRIPTION
base-devel is required as a part of Packer and nowhere else,
as such it should be a part of the aur step

This might conflict with #844 since `pacman -S --noconfirm wget` is removed in that PR
