### PR TITLE
Fix Gemfile with https for github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :kvm do
 end
 
 group :windows do
-  gem "em-winrm", :git => 'http://github.com/hh/em-winrm.git', :ref => '31745601d3'
+  gem "em-winrm", :git => 'https://github.com/hh/em-winrm.git', :ref => '31745601d3'
   gem "log4r"
 end
 


### PR DESCRIPTION
GitHub needs https :

```
$ bundle install
Fetching http://github.com/hh/em-winrm.git
error: RPC failed; result=22, HTTP code = 405
fatal: The remote end hung up unexpectedly
Git error: command `git clone 'http://github.com/hh/em-winrm.git'
"/home/meister/.rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/cache/bundler/git/em-winrm-92096f33e44f28378ca608a4d2323b9abc51cf3a" --bare --no-hardlinks` in directory
/space/ci/veewee has failed.
```
