### PR TITLE
Added Windows 8.1 to known OS types (as Windows81, Windows81_64)

### DIFF
--- a/lib/veewee/config/ostypes.yml
+++ b/lib/veewee/config/ostypes.yml
@@ -19,6 +19,16 @@ Windows8_64:
   :kvm:
   :vbox: Windows8_64
   :parallels: win-8
+Windows81:
+  :fusion:
+  :kvm:
+  :vbox: Windows81
+  :parallels: win-8
+Windows81_64:
+  :fusion:
+  :kvm:
+  :vbox: Windows81_64
+  :parallels: win-8
 WindowsNT:
   :fusion: winNT
   :kvm:


### PR DESCRIPTION
The known OS types currently do not include Windows 8.1, so I added them as `Windows81` and `Windows81_64`, with definitions for vbox (and for parallels, copied from above, even though this just a wild untested guess).
