### PR TITLE
Add templates for CentOS 5.10

### DIFF
--- a/templates/CentOS-5.10-i386-netboot/base.sh
+++ b/templates/CentOS-5.10-i386-netboot/base.sh
@@ -1,0 +1,8 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms bzip2
+
+yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts

--- a/templates/CentOS-5.10-i386-netboot/chef.sh
+++ b/templates/CentOS-5.10-i386-netboot/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+
+curl -L https://www.opscode.com/chef/install.sh | sudo bash

--- a/templates/CentOS-5.10-i386-netboot/cleanup.sh
+++ b/templates/CentOS-5.10-i386-netboot/cleanup.sh
@@ -1,0 +1,8 @@
+# Clean up
+
+yum -y clean all
+rm -rf /etc/yum.repos.d/puppetlabs.repo
+rm -rf VBoxGuestAdditions_*.iso
+
+# Remove mac address from network configuration
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0

--- a/templates/CentOS-5.10-i386-netboot/definition.rb
+++ b/templates/CentOS-5.10-i386-netboot/definition.rb
@@ -1,0 +1,42 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '384',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'on',
+  :virtualbox => {
+    :vm_options => [
+      "pae" => "on",
+      "ioapic" => "on",
+    ],
+  },
+  :os_type_id => 'RedHat',
+  :iso_file => "CentOS-5.10-i386-netinstall.iso",
+  :iso_src => "http://mirrors.kernel.org/centos/5.10/isos/i386/CentOS-5.10-i386-netinstall.iso",
+  :iso_md5 => "8d19b12cb5f65a4b5c2bc61a98abf80c",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "vagrant",
+  :ssh_password => "vagrant",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "ruby.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/CentOS-5.10-i386-netboot/ks.cfg
+++ b/templates/CentOS-5.10-i386-netboot/ks.cfg
@@ -1,0 +1,27 @@
+install
+url --url=http://mirrors.kernel.org/centos/5.10/os/i386/
+lang en_US.UTF-8
+langsupport --default=en_US.UTF-8 en_US.UTF-8
+keyboard us
+text
+skipx
+zerombr
+network --device eth0 --bootproto dhcp
+rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+firewall --enabled --trust eth0 --ssh
+selinux --disabled
+authconfig --enableshadow --enablemd5
+timezone America/New_York
+bootloader --location=mbr
+clearpart --all --initlabel
+autopart
+reboot
+
+%packages
+@ core
+%post
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+%end

--- a/templates/CentOS-5.10-i386-netboot/puppet.sh
+++ b/templates/CentOS-5.10-i386-netboot/puppet.sh
@@ -1,0 +1,17 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/5/dependencies/\$basearch
+enabled=1
+gpgcheck=0
+
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/5/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter ruby-shadow

--- a/templates/CentOS-5.10-i386-netboot/ruby.sh
+++ b/templates/CentOS-5.10-i386-netboot/ruby.sh
@@ -1,0 +1,41 @@
+# Install Ruby from sources
+
+# add epel repo for Ruby compile time dependencies
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=http://download.fedoraproject.org/pub/epel/5/\$basearch
+enabled=1
+gpgcheck=0
+includepkgs=libffi*
+EOM
+
+# Install required library packages
+yum install -y gdbm-devel libffi-devel ncurses-devel
+
+# Install LibYAML (prerequisite for Ruby)
+YAML_VERSION=0.1.4
+wget http://pyyaml.org/download/libyaml/yaml-$YAML_VERSION.tar.gz
+tar xzvf yaml-$YAML_VERSION.tar.gz
+cd yaml-$YAML_VERSION
+./configure --prefix=/opt
+make && make install
+cd ..
+rm -rf yaml-$YAML_VERSION
+rm -f yaml-$YAML_VERSION.tar.gz
+
+# Install Ruby
+RUBY_VERSION=1.9.3-p484
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-$RUBY_VERSION.tar.gz
+tar xvzf ruby-$RUBY_VERSION.tar.gz
+cd ruby-$RUBY_VERSION
+# Fix: BSD compatibility arguments not supported by the installed version of sed
+sed -i "s/sed -E/sed -e/" configure
+./configure --prefix=/opt/ruby --disable-install-doc --with-opt-dir=/opt
+make && make install
+cd ..
+rm -rf ruby-$RUBY_VERSION
+rm -f ruby-$RUBY_VERSION.tar.gz
+
+# remove epel repo
+rm -rf /etc/yum.repos.d/epel.repo

--- a/templates/CentOS-5.10-i386-netboot/vagrant.sh
+++ b/templates/CentOS-5.10-i386-netboot/vagrant.sh
@@ -1,0 +1,9 @@
+# Vagrant configuration
+
+date > /etc/vagrant_box_build_time
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh

--- a/templates/CentOS-5.10-i386-netboot/virtualbox.sh
+++ b/templates/CentOS-5.10-i386-netboot/virtualbox.sh
@@ -1,0 +1,9 @@
+# Installing VirtualBox Guest Additions
+
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+cd /tmp
+mount -o loop /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/vagrant/VBoxGuestAdditions_*.iso
+

--- a/templates/CentOS-5.10-i386-netboot/zerodisk.sh
+++ b/templates/CentOS-5.10-i386-netboot/zerodisk.sh
@@ -1,0 +1,4 @@
+# Zero out the free space to save space in the final image:
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/templates/CentOS-5.10-i386/base.sh
+++ b/templates/CentOS-5.10-i386/base.sh
@@ -1,0 +1,8 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms bzip2
+
+yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts

--- a/templates/CentOS-5.10-i386/chef.sh
+++ b/templates/CentOS-5.10-i386/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+
+curl -L https://www.opscode.com/chef/install.sh | sudo bash

--- a/templates/CentOS-5.10-i386/cleanup.sh
+++ b/templates/CentOS-5.10-i386/cleanup.sh
@@ -1,0 +1,8 @@
+# Clean up
+
+yum -y clean all
+rm -rf /etc/yum.repos.d/puppetlabs.repo
+rm -rf VBoxGuestAdditions_*.iso
+
+# Remove mac address from network configuration
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0

--- a/templates/CentOS-5.10-i386/definition.rb
+++ b/templates/CentOS-5.10-i386/definition.rb
@@ -1,0 +1,42 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '384',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'on',
+  :virtualbox => {
+    :vm_options => [
+      "pae" => "on",
+      "ioapic" => "on",
+    ],
+  },
+  :os_type_id => 'RedHat',
+  :iso_file => "CentOS-5.10-i386-bin-DVD-1of2.iso",
+  :iso_src => "http://mirrors.kernel.org/centos/5.10/isos/i386/CentOS-5.10-i386-bin-DVD-1of2.iso",
+  :iso_md5 => "ec0acc2a4f6a813ea85bf1e36acb03f0",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "vagrant",
+  :ssh_password => "vagrant",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "ruby.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/CentOS-5.10-i386/ks.cfg
+++ b/templates/CentOS-5.10-i386/ks.cfg
@@ -1,0 +1,27 @@
+install
+cdrom
+lang en_US.UTF-8
+langsupport --default=en_US.UTF-8 en_US.UTF-8
+keyboard us
+text
+skipx
+zerombr
+network --device eth0 --bootproto dhcp
+rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+firewall --enabled --trust eth0 --ssh
+selinux --disabled
+authconfig --enableshadow --enablemd5
+timezone America/New_York
+bootloader --location=mbr
+clearpart --all --initlabel
+autopart
+reboot
+
+%packages
+@ core
+%post
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+%end

--- a/templates/CentOS-5.10-i386/puppet.sh
+++ b/templates/CentOS-5.10-i386/puppet.sh
@@ -1,0 +1,17 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/5/dependencies/\$basearch
+enabled=1
+gpgcheck=0
+
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/5/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter ruby-shadow

--- a/templates/CentOS-5.10-i386/ruby.sh
+++ b/templates/CentOS-5.10-i386/ruby.sh
@@ -1,0 +1,41 @@
+# Install Ruby from sources
+
+# add epel repo for Ruby compile time dependencies
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=http://download.fedoraproject.org/pub/epel/5/\$basearch
+enabled=1
+gpgcheck=0
+includepkgs=libffi*
+EOM
+
+# Install required library packages
+yum install -y gdbm-devel libffi-devel ncurses-devel
+
+# Install LibYAML (prerequisite for Ruby)
+YAML_VERSION=0.1.4
+wget http://pyyaml.org/download/libyaml/yaml-$YAML_VERSION.tar.gz
+tar xzvf yaml-$YAML_VERSION.tar.gz
+cd yaml-$YAML_VERSION
+./configure --prefix=/opt
+make && make install
+cd ..
+rm -rf yaml-$YAML_VERSION
+rm -f yaml-$YAML_VERSION.tar.gz
+
+# Install Ruby
+RUBY_VERSION=1.9.3-p484
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-$RUBY_VERSION.tar.gz
+tar xvzf ruby-$RUBY_VERSION.tar.gz
+cd ruby-$RUBY_VERSION
+# Fix: BSD compatibility arguments not supported by the installed version of sed
+sed -i "s/sed -E/sed -e/" configure
+./configure --prefix=/opt/ruby --disable-install-doc --with-opt-dir=/opt
+make && make install
+cd ..
+rm -rf ruby-$RUBY_VERSION
+rm -f ruby-$RUBY_VERSION.tar.gz
+
+# remove epel repo
+rm -rf /etc/yum.repos.d/epel.repo

--- a/templates/CentOS-5.10-i386/vagrant.sh
+++ b/templates/CentOS-5.10-i386/vagrant.sh
@@ -1,0 +1,9 @@
+# Vagrant configuration
+
+date > /etc/vagrant_box_build_time
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh

--- a/templates/CentOS-5.10-i386/virtualbox.sh
+++ b/templates/CentOS-5.10-i386/virtualbox.sh
@@ -1,0 +1,9 @@
+# Installing VirtualBox Guest Additions
+
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+cd /tmp
+mount -o loop /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/vagrant/VBoxGuestAdditions_*.iso
+

--- a/templates/CentOS-5.10-i386/zerodisk.sh
+++ b/templates/CentOS-5.10-i386/zerodisk.sh
@@ -1,0 +1,4 @@
+# Zero out the free space to save space in the final image:
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/templates/CentOS-5.10-x86_64-netboot/base.sh
+++ b/templates/CentOS-5.10-x86_64-netboot/base.sh
@@ -1,0 +1,8 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms bzip2
+
+yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts

--- a/templates/CentOS-5.10-x86_64-netboot/chef.sh
+++ b/templates/CentOS-5.10-x86_64-netboot/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+
+curl -L https://www.opscode.com/chef/install.sh | sudo bash

--- a/templates/CentOS-5.10-x86_64-netboot/cleanup.sh
+++ b/templates/CentOS-5.10-x86_64-netboot/cleanup.sh
@@ -1,0 +1,8 @@
+# Clean up
+
+yum -y clean all
+rm -rf /etc/yum.repos.d/puppetlabs.repo
+rm -rf VBoxGuestAdditions_*.iso
+
+# Remove mac address from network configuration
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0

--- a/templates/CentOS-5.10-x86_64-netboot/definition.rb
+++ b/templates/CentOS-5.10-x86_64-netboot/definition.rb
@@ -1,0 +1,42 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '384',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'on',
+  :virtualbox => {
+    :vm_options => [
+      "pae" => "on",
+      "ioapic" => "on",
+    ],
+  },
+  :os_type_id => 'RedHat_64',
+  :iso_file => "CentOS-5.10-x86_64-netinstall.iso",
+  :iso_src => "http://mirrors.kernel.org/centos/5.10/isos/x86_64/CentOS-5.10-x86_64-netinstall.iso",
+  :iso_md5 => "e09e44f04f0a4b97b04935e0ba88833f",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "vagrant",
+  :ssh_password => "vagrant",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "ruby.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/CentOS-5.10-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-5.10-x86_64-netboot/ks.cfg
@@ -1,0 +1,27 @@
+install
+url --url=http://mirrors.kernel.org/centos/5.10/os/x86_64/
+lang en_US.UTF-8
+langsupport --default=en_US.UTF-8 en_US.UTF-8
+keyboard us
+text
+skipx
+zerombr
+network --device eth0 --bootproto dhcp
+rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+firewall --enabled --trust eth0 --ssh
+selinux --disabled
+authconfig --enableshadow --enablemd5
+timezone America/New_York
+bootloader --location=mbr
+clearpart --all --initlabel
+autopart
+reboot
+
+%packages
+@ core
+%post
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+%end

--- a/templates/CentOS-5.10-x86_64-netboot/puppet.sh
+++ b/templates/CentOS-5.10-x86_64-netboot/puppet.sh
@@ -1,0 +1,17 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/5/dependencies/\$basearch
+enabled=1
+gpgcheck=0
+
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/5/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter ruby-shadow

--- a/templates/CentOS-5.10-x86_64-netboot/ruby.sh
+++ b/templates/CentOS-5.10-x86_64-netboot/ruby.sh
@@ -1,0 +1,41 @@
+# Install Ruby from sources
+
+# add epel repo for Ruby compile time dependencies
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=http://download.fedoraproject.org/pub/epel/5/\$basearch
+enabled=1
+gpgcheck=0
+includepkgs=libffi*
+EOM
+
+# Install required library packages
+yum install -y gdbm-devel libffi-devel ncurses-devel
+
+# Install LibYAML (prerequisite for Ruby)
+YAML_VERSION=0.1.4
+wget http://pyyaml.org/download/libyaml/yaml-$YAML_VERSION.tar.gz
+tar xzvf yaml-$YAML_VERSION.tar.gz
+cd yaml-$YAML_VERSION
+./configure --prefix=/opt
+make && make install
+cd ..
+rm -rf yaml-$YAML_VERSION
+rm -f yaml-$YAML_VERSION.tar.gz
+
+# Install Ruby
+RUBY_VERSION=1.9.3-p484
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-$RUBY_VERSION.tar.gz
+tar xvzf ruby-$RUBY_VERSION.tar.gz
+cd ruby-$RUBY_VERSION
+# Fix: BSD compatibility arguments not supported by the installed version of sed
+sed -i "s/sed -E/sed -e/" configure
+./configure --prefix=/opt/ruby --disable-install-doc --with-opt-dir=/opt
+make && make install
+cd ..
+rm -rf ruby-$RUBY_VERSION
+rm -f ruby-$RUBY_VERSION.tar.gz
+
+# remove epel repo
+rm -rf /etc/yum.repos.d/epel.repo

--- a/templates/CentOS-5.10-x86_64-netboot/vagrant.sh
+++ b/templates/CentOS-5.10-x86_64-netboot/vagrant.sh
@@ -1,0 +1,9 @@
+# Vagrant configuration
+
+date > /etc/vagrant_box_build_time
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh

--- a/templates/CentOS-5.10-x86_64-netboot/virtualbox.sh
+++ b/templates/CentOS-5.10-x86_64-netboot/virtualbox.sh
@@ -1,0 +1,9 @@
+# Installing VirtualBox Guest Additions
+
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+cd /tmp
+mount -o loop /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/vagrant/VBoxGuestAdditions_*.iso
+

--- a/templates/CentOS-5.10-x86_64-netboot/zerodisk.sh
+++ b/templates/CentOS-5.10-x86_64-netboot/zerodisk.sh
@@ -1,0 +1,4 @@
+# Zero out the free space to save space in the final image:
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/templates/CentOS-5.10-x86_64/base.sh
+++ b/templates/CentOS-5.10-x86_64/base.sh
@@ -1,0 +1,8 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms bzip2
+
+yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts

--- a/templates/CentOS-5.10-x86_64/chef.sh
+++ b/templates/CentOS-5.10-x86_64/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+
+curl -L https://www.opscode.com/chef/install.sh | sudo bash

--- a/templates/CentOS-5.10-x86_64/cleanup.sh
+++ b/templates/CentOS-5.10-x86_64/cleanup.sh
@@ -1,0 +1,8 @@
+# Clean up
+
+yum -y clean all
+rm -rf /etc/yum.repos.d/puppetlabs.repo
+rm -rf VBoxGuestAdditions_*.iso
+
+# Remove mac address from network configuration
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0

--- a/templates/CentOS-5.10-x86_64/definition.rb
+++ b/templates/CentOS-5.10-x86_64/definition.rb
@@ -1,0 +1,42 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '384',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'on',
+  :virtualbox => {
+    :vm_options => [
+      "pae" => "on",
+      "ioapic" => "on",
+    ],
+  },
+  :os_type_id => 'RedHat_64',
+  :iso_file => "CentOS-5.10-x86_64-bin-DVD-1of2.iso",
+  :iso_src => "http://mirrors.kernel.org/centos/5.10/isos/x86_64/CentOS-5.10-x86_64-bin-DVD-1of2.iso",
+  :iso_md5 => "715f7355074c00530cd6ee1d9f43cc3f",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [ 'linux text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "vagrant",
+  :ssh_password => "vagrant",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "ruby.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/CentOS-5.10-x86_64/ks.cfg
+++ b/templates/CentOS-5.10-x86_64/ks.cfg
@@ -1,0 +1,27 @@
+install
+cdrom
+lang en_US.UTF-8
+langsupport --default=en_US.UTF-8 en_US.UTF-8
+keyboard us
+text
+skipx
+zerombr
+network --device eth0 --bootproto dhcp
+rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+firewall --enabled --trust eth0 --ssh
+selinux --disabled
+authconfig --enableshadow --enablemd5
+timezone America/New_York
+bootloader --location=mbr
+clearpart --all --initlabel
+autopart
+reboot
+
+%packages
+@ core
+%post
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+%end

--- a/templates/CentOS-5.10-x86_64/puppet.sh
+++ b/templates/CentOS-5.10-x86_64/puppet.sh
@@ -1,0 +1,17 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/5/dependencies/\$basearch
+enabled=1
+gpgcheck=0
+
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/5/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter ruby-shadow

--- a/templates/CentOS-5.10-x86_64/ruby.sh
+++ b/templates/CentOS-5.10-x86_64/ruby.sh
@@ -1,0 +1,41 @@
+# Install Ruby from sources
+
+# add epel repo for Ruby compile time dependencies
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=http://download.fedoraproject.org/pub/epel/5/\$basearch
+enabled=1
+gpgcheck=0
+includepkgs=libffi*
+EOM
+
+# Install required library packages
+yum install -y gdbm-devel libffi-devel ncurses-devel
+
+# Install LibYAML (prerequisite for Ruby)
+YAML_VERSION=0.1.4
+wget http://pyyaml.org/download/libyaml/yaml-$YAML_VERSION.tar.gz
+tar xzvf yaml-$YAML_VERSION.tar.gz
+cd yaml-$YAML_VERSION
+./configure --prefix=/opt
+make && make install
+cd ..
+rm -rf yaml-$YAML_VERSION
+rm -f yaml-$YAML_VERSION.tar.gz
+
+# Install Ruby
+RUBY_VERSION=1.9.3-p484
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-$RUBY_VERSION.tar.gz
+tar xvzf ruby-$RUBY_VERSION.tar.gz
+cd ruby-$RUBY_VERSION
+# Fix: BSD compatibility arguments not supported by the installed version of sed
+sed -i "s/sed -E/sed -e/" configure
+./configure --prefix=/opt/ruby --disable-install-doc --with-opt-dir=/opt
+make && make install
+cd ..
+rm -rf ruby-$RUBY_VERSION
+rm -f ruby-$RUBY_VERSION.tar.gz
+
+# remove epel repo
+rm -rf /etc/yum.repos.d/epel.repo

--- a/templates/CentOS-5.10-x86_64/vagrant.sh
+++ b/templates/CentOS-5.10-x86_64/vagrant.sh
@@ -1,0 +1,9 @@
+# Vagrant configuration
+
+date > /etc/vagrant_box_build_time
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh

--- a/templates/CentOS-5.10-x86_64/virtualbox.sh
+++ b/templates/CentOS-5.10-x86_64/virtualbox.sh
@@ -1,0 +1,9 @@
+# Installing VirtualBox Guest Additions
+
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+cd /tmp
+mount -o loop /home/vagrant/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/vagrant/VBoxGuestAdditions_*.iso
+

--- a/templates/CentOS-5.10-x86_64/zerodisk.sh
+++ b/templates/CentOS-5.10-x86_64/zerodisk.sh
@@ -1,0 +1,4 @@
+# Zero out the free space to save space in the final image:
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY


### PR DESCRIPTION
New templates for CentOS 5.10 (x86_64/i386, ISO/netboot); loosely based on previous CentOS templates, but with the following changes and improvements:
- Updated Ruby to version 1.9.3-p484
- Chef installation via Opscode script
- Consolidated scripts; removed redundant/unused script parts
- Enabled Virtual Box Host IO Cache (Vagrant default setting)
