### PR TITLE
mime-types 1.16 dependency

### DIFF
--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "grit"
   s.add_dependency "fission", "0.4.0"
   s.add_dependency "os", "~> 0.9.6"
+  s.add_dependency "mime-types", "~> 1.16"
 
   s.required_ruby_version = '>= 1.9.2'
 


### PR DESCRIPTION
Grit depends on mime-types ~> 1.15, Fog depends on mime-types ~>1.16, gem in its shortsightedness installs 1.15 for Grit and 2.0 for Fog, then they don't work together.
/usr/local/rvm/rubies/ruby-1.9.2-p320/lib/ruby/1.9.1/rubygems.rb:238:in `activate': can't activate mime-types (~> 1.15, runtime) for ["grit-2.5.0", "veewee-0.3.12"], already activated mime-types-2.0 for ["fog-1.19.0", "veewee-0.3.12"](Gem::LoadError)

If mime-types 1.16 is installed, grit and fog are happy and don't pull in incompatible versions.
