### PR TITLE
mime-types ~> 1.16 dependency

### DIFF
--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "grit"
   s.add_dependency "fission", "0.4.0"
   s.add_dependency "os", "~> 0.9.6"
+  s.add_dependency "mime-types", "~> 1.16"
 
   s.required_ruby_version = '>= 1.9.2'
 


### PR DESCRIPTION
A clean "gem install veewee" fails as Fog installs mime-types 2.0, but Grit depends ~>1.15.  Fog depends ~>1.16, so we can make everyone happy with a ~>1.16 dependency.
