### PR TITLE
Order of add_dependency is important, mail-types must come before fog.

### DIFF
--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   # DEBUG_RESOLVER=1 bundle install
   s.add_dependency "net-ssh", ">= 2.2.0"
 
+  s.add_dependency "mime-types", "~> 1.16"
   s.add_dependency "popen4", "~> 0.1.2"
   s.add_dependency "thor", "~> 0.15"
   s.add_dependency "highline"
@@ -35,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_dependency "grit"
   s.add_dependency "fission", "0.4.0"
   s.add_dependency "os", "~> 0.9.6"
-  s.add_dependency "mime-types", "~> 1.16"
 
   s.required_ruby_version = '>= 1.9.2'
 


### PR DESCRIPTION
if s.add_dependency "mime-types", "~> 1.16" is specified below fog, gem considers fog first and its requirement on mime-types >= 0 and pulls in mime-types 2.0.  I gave gem too much credit for calculating dependency ordering, it does _not_ do that at all.

Apologies for prematurely pushing last fix jedi4ever, this one builds :)
