### PR TITLE
Fixes CentOS 6.2 chef.sh install issue

### DIFF
--- a/templates/CentOS-6.2-i386-minimal/chef.sh
+++ b/templates/CentOS-6.2-i386-minimal/chef.sh
@@ -1,3 +1,4 @@
 # Install Chef
+gem install --no-ri --no-rdoc mime-types -v '1.16'
 gem install --no-ri --no-rdoc chef
 

--- a/templates/CentOS-6.2-x86_64-minimal/chef.sh
+++ b/templates/CentOS-6.2-x86_64-minimal/chef.sh
@@ -1,3 +1,4 @@
 # Install Chef
+gem install --no-ri --no-rdoc mime-types -v '1.16'
 gem install --no-ri --no-rdoc chef
 

--- a/templates/CentOS-6.2-x86_64-netboot/chef.sh
+++ b/templates/CentOS-6.2-x86_64-netboot/chef.sh
@@ -1,3 +1,4 @@
 # Install Chef
+gem install --no-ri --no-rdoc mime-types -v '1.16'
 gem install --no-ri --no-rdoc chef
 


### PR DESCRIPTION
Adding explicit version install of mime-types (chef dependecy). The latest version needs a higher ruby version (>= 1.9.3)  than the one available in CentOS 6.2 repositories (1.8.7)
