### PR TITLE
Improve CentOS 5.10 templates: Do not remove wireless-tools package

### DIFF
--- a/templates/CentOS-5.10-i386-netboot/base.sh
+++ b/templates/CentOS-5.10-i386-netboot/base.sh
@@ -5,4 +5,4 @@ sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
 
 yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms bzip2
 
-yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts
+yum -y erase gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts

--- a/templates/CentOS-5.10-i386/base.sh
+++ b/templates/CentOS-5.10-i386/base.sh
@@ -5,4 +5,4 @@ sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
 
 yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms bzip2
 
-yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts
+yum -y erase gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts

--- a/templates/CentOS-5.10-x86_64-netboot/base.sh
+++ b/templates/CentOS-5.10-x86_64-netboot/base.sh
@@ -5,4 +5,4 @@ sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
 
 yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms bzip2
 
-yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts
+yum -y erase gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts

--- a/templates/CentOS-5.10-x86_64/base.sh
+++ b/templates/CentOS-5.10-x86_64/base.sh
@@ -5,4 +5,4 @@ sed -i "s/^\(.*env_keep = \"\)/\1PATH /" /etc/sudoers
 
 yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms bzip2
 
-yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts
+yum -y erase gtk2 libX11 hicolor-icon-theme freetype bitstream-vera-fonts


### PR DESCRIPTION
The wireless-tools package hosts the libiw.so.28 shared library that is used by system utilities such as iwconfig. Removing libiw.so.28 causes error messages during system startup when network interfaces are brought up ("iwconfig: error while loading shared libraries: [...]").

Signed-off-by: Gregor Zurowski gregor@zurowski.org
