### PR TITLE
SSH connection test now works if it can connect even without receiving the existing connection error.

### DIFF
--- a/lib/veewee/provider/core/helper/ssh.rb
+++ b/lib/veewee/provider/core/helper/ssh.rb
@@ -33,7 +33,11 @@ module Veewee
               rescue IO::WaitWritable
                 if IO.select(nil, [socket], nil, timeout)
                   begin
-                    socket.connect_nonblock(sockaddr)
+                    result = socket.connect_nonblock(sockaddr)
+                    if result == 0 
+                      socket.close
+                      return true
+                    end
                   rescue Errno::EISCONN
                     socket.close
                     return true


### PR DESCRIPTION
tcp_test_ssh now checks the return from the second socket.connect_nonblock and will return true if that connection attempt was successful.

This fixed a problem on my system where tcp_test_ssh would never return successfully even though I could connect with ssh. It appears the cause was that the second socket.connect_nonblock would return success (0) and not the expected EISCONN. It is unclear to me why the original code expected an existing connection. Possibly it was expecting longer timeouts than my system might have.
