### PR TITLE
FreeBSD-10: Reduce box size

### DIFF
--- a/templates/freebsd-10.0-RELEASE-amd64/postinstall.csh
+++ b/templates/freebsd-10.0-RELEASE-amd64/postinstall.csh
@@ -75,6 +75,8 @@ tar -k -C / -xf /tmp/lib32.txz
 cd /usr/ports/emulators/virtualbox-ose-additions
 make -DBATCH package clean
 
+cp /usr/local/etc/pkg.conf.sample /usr/local/etc/pkg.conf
+
 # undo our customizations
 sed -i '' -e '/^REFUSE /d' /etc/portsnap.conf
 # sed -i '' -e '/^WITHOUT_X11/d' /etc/make.conf


### PR DESCRIPTION
Creates a box that is only 700MB - using the method from @wunki's [setup script](https://github.com/wunki/vagrant-freebsd/blob/master/bin/vagrant-setup.sh#L87)

```
-rw-r--r--    1 scollins  staff   701M Jan 25 19:17 freebsd10.box
```
