### PR TITLE
Exit with a non-zero exit code if something goes wrong

### DIFF
--- a/bin/veewee
+++ b/bin/veewee
@@ -25,4 +25,5 @@ begin
 
 rescue Veewee::Error => e
   env.ui.error "#{e}"
+  exit 1
 end


### PR DESCRIPTION
Veewee currently exits with code 0 if something goes wrong. This messes up my automation scripts. This change makes it exit with a non-zero code on error.
