### PR TITLE
Correctly escape commands passed to 'veewee <provider> ssh', properly use SSH key

### DIFF
--- a/lib/veewee/provider/core/box/ssh.rb
+++ b/lib/veewee/provider/core/box/ssh.rb
@@ -40,8 +40,10 @@ module Veewee
             "-o IdentitiesOnly=yes",
             "-o VerifyHostKeyDNS=no"
           ]
-          if !(definition.ssh_key.nil? ||  definition.ssh_key.length!="")
-            command_options << "-i #{definition.ssh_key}"
+          if !(definition.ssh_key.nil? ||  definition.ssh_key.empty?)
+            # Filenames of SSH keys are relative to their definition
+            ssh_key = File.join(definition.path, definition.ssh_key)
+            command_options << "-i #{ssh_key}"
           end
           commandline_options="#{command_options.join(" ")} ".strip
 


### PR DESCRIPTION
`veewee <provider> ssh` would previously fail on complex commands, e.g. commands that contain `"`. This fixes it. It is now possible to pass arbitrary commands to `veewee <provider> ssh`.

It would also not correctly use the SSH key specified in the definition file. That has also been fixed.
