### PR TITLE
Set 'vagrant' as root password for CentOS 5.9 and 5.10.

### DIFF
--- a/templates/CentOS-5.10-i386-netboot/ks.cfg
+++ b/templates/CentOS-5.10-i386-netboot/ks.cfg
@@ -7,7 +7,7 @@ text
 skipx
 zerombr
 network --device eth0 --bootproto dhcp
-rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+rootpw vagrant
 firewall --enabled --trust eth0 --ssh
 selinux --disabled
 authconfig --enableshadow --enablemd5

--- a/templates/CentOS-5.10-i386/ks.cfg
+++ b/templates/CentOS-5.10-i386/ks.cfg
@@ -7,7 +7,7 @@ text
 skipx
 zerombr
 network --device eth0 --bootproto dhcp
-rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+rootpw vagrant
 firewall --enabled --trust eth0 --ssh
 selinux --disabled
 authconfig --enableshadow --enablemd5

--- a/templates/CentOS-5.10-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-5.10-x86_64-netboot/ks.cfg
@@ -7,7 +7,7 @@ text
 skipx
 zerombr
 network --device eth0 --bootproto dhcp
-rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+rootpw vagrant
 firewall --enabled --trust eth0 --ssh
 selinux --disabled
 authconfig --enableshadow --enablemd5

--- a/templates/CentOS-5.10-x86_64/ks.cfg
+++ b/templates/CentOS-5.10-x86_64/ks.cfg
@@ -7,7 +7,7 @@ text
 skipx
 zerombr
 network --device eth0 --bootproto dhcp
-rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+rootpw vagrant
 firewall --enabled --trust eth0 --ssh
 selinux --disabled
 authconfig --enableshadow --enablemd5

--- a/templates/CentOS-5.9-i386-netboot/ks.cfg
+++ b/templates/CentOS-5.9-i386-netboot/ks.cfg
@@ -7,7 +7,7 @@ text
 skipx
 zerombr
 network --device eth0 --bootproto dhcp
-rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+rootpw vagrant
 firewall --enabled --trust eth0 --ssh
 selinux --disabled
 authconfig --enableshadow --enablemd5

--- a/templates/CentOS-5.9-i386/ks.cfg
+++ b/templates/CentOS-5.9-i386/ks.cfg
@@ -7,7 +7,7 @@ text
 skipx
 zerombr
 network --device eth0 --bootproto dhcp
-rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+rootpw vagrant
 firewall --enabled --trust eth0 --ssh
 selinux --disabled
 authconfig --enableshadow --enablemd5

--- a/templates/CentOS-5.9-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-5.9-x86_64-netboot/ks.cfg
@@ -7,7 +7,7 @@ text
 skipx
 zerombr
 network --device eth0 --bootproto dhcp
-rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+rootpw vagrant
 firewall --enabled --trust eth0 --ssh
 selinux --disabled
 authconfig --enableshadow --enablemd5

--- a/templates/CentOS-5.9-x86_64/ks.cfg
+++ b/templates/CentOS-5.9-x86_64/ks.cfg
@@ -7,7 +7,7 @@ text
 skipx
 zerombr
 network --device eth0 --bootproto dhcp
-rootpw --iscrypted $1$vSG8FjAu$ekQ0grf16hS4G93HTPcco/
+rootpw vagrant
 firewall --enabled --trust eth0 --ssh
 selinux --disabled
 authconfig --enableshadow --enablemd5


### PR DESCRIPTION
Signed-off-by: Gregor Zurowski gregor@zurowski.org
