### PR TITLE
Fix VMware Tools on CentOS-6.5 and CentOS-6.4

### DIFF
--- a/templates/CentOS-6.4-i386-minimal/vmfusion.sh
+++ b/templates/CentOS-6.4-i386-minimal/vmfusion.sh
@@ -1,3 +1,6 @@
+# vmware-vmblock-fuse requires libfuse.so
+yum -y install fuse-libs
+
 cd /tmp
 mkdir -p /mnt/cdrom
 mount -o loop /home/veewee/linux.iso /mnt/cdrom

--- a/templates/CentOS-6.4-i386-netboot/vmfusion.sh
+++ b/templates/CentOS-6.4-i386-netboot/vmfusion.sh
@@ -1,3 +1,6 @@
+# vmware-vmblock-fuse requires libfuse.so
+yum -y install fuse-libs
+
 cd /tmp
 mkdir -p /mnt/cdrom
 mount -o loop /home/veewee/linux.iso /mnt/cdrom

--- a/templates/CentOS-6.4-x86_64-minimal/vmfusion.sh
+++ b/templates/CentOS-6.4-x86_64-minimal/vmfusion.sh
@@ -1,3 +1,6 @@
+# vmware-vmblock-fuse requires libfuse.so
+yum -y install fuse-libs
+
 cd /tmp
 mkdir -p /mnt/cdrom
 mount -o loop /home/veewee/linux.iso /mnt/cdrom

--- a/templates/CentOS-6.4-x86_64-netboot/vmfusion.sh
+++ b/templates/CentOS-6.4-x86_64-netboot/vmfusion.sh
@@ -1,3 +1,6 @@
+# vmware-vmblock-fuse requires libfuse.so
+yum -y install fuse-libs
+
 cd /tmp
 mkdir -p /mnt/cdrom
 mount -o loop /home/veewee/linux.iso /mnt/cdrom

--- a/templates/CentOS-6.5-i386-minimal/vmfusion.sh
+++ b/templates/CentOS-6.5-i386-minimal/vmfusion.sh
@@ -1,3 +1,6 @@
+# vmware-vmblock-fuse requires libfuse.so
+yum -y install fuse-libs
+
 cd /tmp
 mkdir -p /mnt/cdrom
 mount -o loop /home/veewee/linux.iso /mnt/cdrom

--- a/templates/CentOS-6.5-i386-netboot/vmfusion.sh
+++ b/templates/CentOS-6.5-i386-netboot/vmfusion.sh
@@ -1,3 +1,6 @@
+# vmware-vmblock-fuse requires libfuse.so
+yum -y install fuse-libs
+
 cd /tmp
 mkdir -p /mnt/cdrom
 mount -o loop /home/veewee/linux.iso /mnt/cdrom

--- a/templates/CentOS-6.5-x86_64-minimal/vmfusion.sh
+++ b/templates/CentOS-6.5-x86_64-minimal/vmfusion.sh
@@ -1,3 +1,6 @@
+# vmware-vmblock-fuse requires libfuse.so
+yum -y install fuse-libs
+
 cd /tmp
 mkdir -p /mnt/cdrom
 mount -o loop /home/veewee/linux.iso /mnt/cdrom

--- a/templates/CentOS-6.5-x86_64-netboot/vmfusion.sh
+++ b/templates/CentOS-6.5-x86_64-netboot/vmfusion.sh
@@ -1,3 +1,6 @@
+# vmware-vmblock-fuse requires libfuse.so
+yum -y install fuse-libs
+
 cd /tmp
 mkdir -p /mnt/cdrom
 mount -o loop /home/veewee/linux.iso /mnt/cdrom


### PR DESCRIPTION
The vmfusion.sh script will now attempt to install fuse-libs before the installing VMware Tools.

This commit will resolve #906 for CentOS-6.4 and CentOS-6.5.
