### PR TITLE
fix fusion box template for VMware Fusion v. 6

### DIFF
--- a/lib/veewee/provider/vmfusion/box/template.vmx.erb
+++ b/lib/veewee/provider/vmfusion/box/template.vmx.erb
@@ -96,7 +96,7 @@ sound.startConnected = "FALSE"
 RemoteDisplay.vnc.enabled = "TRUE"
 RemoteDisplay.vnc.port = "<%= vnc_port %>"
 <% if enable_hypervisor_support == true %>vhv.enable = "TRUE"<% end %>
-<% if fusion_version.start_with?('5.') %>bios.bootOrder = "hdd,CDROM"<% end %>
+<% if fusion_version.match(/[6|5]\./) %>bios.bootOrder = "hdd,CDROM"<% end %>
 <% unless vmdk_file.nil? %>
 scsi0:2.present = "TRUE"
 scsi0:2.fileName = "<%= vmdk_file %>"


### PR DESCRIPTION
Fixes #909. The template only set the boot order for VMWare fusion 5, this adds 6
