### PR TITLE
Make Debian template compatible with non-vbox providers

### DIFF
--- a/templates/Debian-7.4.0-amd64-netboot/cleanup-virtualbox.sh
+++ b/templates/Debian-7.4.0-amd64-netboot/cleanup-virtualbox.sh
@@ -1,4 +1,0 @@
-# Cleanup Virtualbox
-VBOX_VERSION=$(cat .vbox_version)
-VBOX_ISO=VBoxGuestAdditions_$VBOX_VERSION.iso
-rm $VBOX_ISO

--- a/templates/Debian-7.4.0-amd64-netboot/definition.rb
+++ b/templates/Debian-7.4.0-amd64-netboot/definition.rb
@@ -45,7 +45,6 @@ Veewee::Definition.declare({
     "ruby.sh",
     "puppet.sh",
     "chef.sh",
-    "cleanup-virtualbox.sh",
     "cleanup.sh",
     "zerodisk.sh"
   ],

--- a/templates/Debian-7.4.0-amd64-netboot/virtualbox.sh
+++ b/templates/Debian-7.4.0-amd64-netboot/virtualbox.sh
@@ -21,7 +21,6 @@ if test -f .vbox_version ; then
   yes|sh /mnt/VBoxLinuxAdditions.run
   umount /mnt
 
-
   # Start the newly build driver
   /etc/init.d/vboxadd start
 
@@ -30,5 +29,7 @@ if test -f .vbox_version ; then
 
   # Test mount the veewee-validation
   mount -t vboxsf veewee-validation /tmp/veewee-validation
+
+  rm /tmp/$VBOX_ISO
 
 fi

--- a/templates/Debian-7.4.0-i386-netboot/cleanup-virtualbox.sh
+++ b/templates/Debian-7.4.0-i386-netboot/cleanup-virtualbox.sh
@@ -1,4 +1,0 @@
-# Cleanup Virtualbox
-VBOX_VERSION=$(cat .vbox_version)
-VBOX_ISO=VBoxGuestAdditions_$VBOX_VERSION.iso
-rm $VBOX_ISO

--- a/templates/Debian-7.4.0-i386-netboot/definition.rb
+++ b/templates/Debian-7.4.0-i386-netboot/definition.rb
@@ -43,7 +43,6 @@ Veewee::Definition.declare({
     "ruby.sh",
     "puppet.sh",
     "chef.sh",
-    "cleanup-virtualbox.sh",
     "cleanup.sh",
     "zerodisk.sh"
   ],

--- a/templates/Debian-7.4.0-i386-netboot/virtualbox.sh
+++ b/templates/Debian-7.4.0-i386-netboot/virtualbox.sh
@@ -17,10 +17,11 @@ if test -f .vbox_version ; then
   # Install the VirtualBox guest additions
   VBOX_VERSION=$(cat .vbox_version)
   VBOX_ISO=VBoxGuestAdditions_$VBOX_VERSION.iso
+  curl -Lo /tmp/VBoxGuestAdditions_$VBOX_VERSION.iso \
+    "http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso"
   mount -o loop $VBOX_ISO /mnt
   yes|sh /mnt/VBoxLinuxAdditions.run
   umount /mnt
-
 
   # Start the newly build driver
   /etc/init.d/vboxadd start
@@ -30,5 +31,8 @@ if test -f .vbox_version ; then
 
   # Test mount the veewee-validation
   mount -t vboxsf veewee-validation /tmp/veewee-validation
+
+  # Implement old cleanup-virtualbox.sh
+  rm /tmp/$VBOX_ISO
 
 fi


### PR DESCRIPTION
By moving virtualbox logic all within logic that checks if it _is_ within a vbox environment, you can reuse the template safely with other providers like libvirt/kvm. Also making sure you have the vbox guest
additions.
