### PR TITLE
Made a mistake on vbox guest utils downloads for debian, improving dc7e52f

### DIFF
--- a/templates/Debian-7.4.0-amd64-netboot/virtualbox.sh
+++ b/templates/Debian-7.4.0-amd64-netboot/virtualbox.sh
@@ -30,6 +30,6 @@ if test -f .vbox_version ; then
   # Test mount the veewee-validation
   mount -t vboxsf veewee-validation /tmp/veewee-validation
 
-  rm /tmp/$VBOX_ISO
+  rm $VBOX_ISO
 
 fi

--- a/templates/Debian-7.4.0-i386-netboot/virtualbox.sh
+++ b/templates/Debian-7.4.0-i386-netboot/virtualbox.sh
@@ -17,8 +17,6 @@ if test -f .vbox_version ; then
   # Install the VirtualBox guest additions
   VBOX_VERSION=$(cat .vbox_version)
   VBOX_ISO=VBoxGuestAdditions_$VBOX_VERSION.iso
-  curl -Lo /tmp/VBoxGuestAdditions_$VBOX_VERSION.iso \
-    "http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso"
   mount -o loop $VBOX_ISO /mnt
   yes|sh /mnt/VBoxLinuxAdditions.run
   umount /mnt
@@ -33,6 +31,6 @@ if test -f .vbox_version ; then
   mount -t vboxsf veewee-validation /tmp/veewee-validation
 
   # Implement old cleanup-virtualbox.sh
-  rm /tmp/$VBOX_ISO
+  rm $VBOX_ISO
 
 fi


### PR DESCRIPTION
The curl isn't needed, given the helper guest utils downloads, which puts things in /root/ and not /tmp anyway.
