### PR TITLE
Freebsd 10 template tweaks

### DIFF
--- a/templates/freebsd-10.0-RELEASE-amd64/definition.rb
+++ b/templates/freebsd-10.0-RELEASE-amd64/definition.rb
@@ -29,20 +29,25 @@ Veewee::Definition.declare({
     '<Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait>',
     '<Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait>',
     '<Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait>',
-    '<Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait>',
-    '<Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait>',
-    '<Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait><Wait>',
     'root',
+    '<Enter>',
     '<Enter>',
     'dhclient em0',
     '<Enter><Wait><Wait><Wait>',
     'fetch -o /tmp/install.sh http://%IP%:%PORT%/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh %NAME%<Enter>'
   ],
-:kickstart_port => "7122", :kickstart_timeout => "10000", :kickstart_file => "install.sh",
-  :ssh_login_timeout => "10000", :ssh_user => "vagrant", :ssh_password => "vagrant", :ssh_key => "",
-  :ssh_host_port => "7222", :ssh_guest_port => "22",
-  :sudo_cmd => "cat '%f' | su -",
+  :kickstart_port => "7122",
+  :kickstart_timeout => "25000",
+  :kickstart_file => "install.sh",
+  :ssh_login_timeout => "25000",
+  :ssh_user => "vagrant",
+  :ssh_password => "vagrant",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "sudo /bin/sh '%f'",
   :shutdown_cmd => "shutdown -p now",
-  :postinstall_files => [ "postinstall.csh"], :postinstall_timeout => "10000"
-
+  :postinstall_files => [ "postinstall.sh"],
+  :postinstall_timeout => "25000"
 })
+

--- a/templates/freebsd-10.0-RELEASE-amd64/install.sh
+++ b/templates/freebsd-10.0-RELEASE-amd64/install.sh
@@ -21,12 +21,24 @@ if_vtnet_load="YES"
 virtio_balloon_load="YES"
 EOT
 
+export ASSUME_ALWAYS_YES=YES
+pkg bootstrap
+pkg2ng
+
+mv -vf /usr/local/etc/pkg.conf.sample /usr/local/etc/pkg.conf
+
+# Install binary packages versions of dependencies
+pkg install -y sudo bash-static
+
 # Set up user accounts
 zfs create tank/root/home
 zfs create tank/root/home/vagrant
-echo "vagrant" | pw -V /etc useradd vagrant -h 0 -s csh -G wheel -d /home/vagrant -c "Vagrant User"
+echo "vagrant" | pw -V /etc useradd vagrant -h 0 -s /usr/local/bin/bash -G wheel -d /home/vagrant -c "Vagrant User"
 
-chown 1001:1001 /home/vagrant
+chown -R vagrant:vagrant /home/vagrant
+
+# Enable passwordless sudo
+echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /usr/local/etc/sudoers
 
 # Reboot
 reboot


### PR DESCRIPTION
- `:sudo_cmd` changed to actually use `sudo` instead of `su`. The latter really only works as long as the `root` user's password is empty.
- Installs `pkg` early in the process so that `bash-static` and `sudo` can be part of the system early on. Allows for `bash` to be set as the `vagrant` user's shell and also allows for `postinstall.sh` to be a `sh` script instead of (horror) `csh`
- Tweaked install of `ca_root_nss` to set `WITH='ETCSYMLINK'` on the command line so it doesn't have to be in `make.conf`
