### PR TITLE
Fix Debian 7 build failure: Make apt-get non-interactive to workaround interactive openssl update prompt

### DIFF
--- a/templates/Debian-7.0-amd64-netboot/base.sh
+++ b/templates/Debian-7.0-amd64-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev

--- a/templates/Debian-7.0-i386-netboot/base.sh
+++ b/templates/Debian-7.0-i386-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev

--- a/templates/Debian-7.1.0-amd64-netboot/base.sh
+++ b/templates/Debian-7.1.0-amd64-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev

--- a/templates/Debian-7.1.0-i386-netboot/base.sh
+++ b/templates/Debian-7.1.0-i386-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev

--- a/templates/Debian-7.2.0-amd64-netboot/base.sh
+++ b/templates/Debian-7.2.0-amd64-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev

--- a/templates/Debian-7.2.0-i386-netboot/base.sh
+++ b/templates/Debian-7.2.0-i386-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev

--- a/templates/Debian-7.3.0-amd64-netboot/base.sh
+++ b/templates/Debian-7.3.0-amd64-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev

--- a/templates/Debian-7.3.0-i386-netboot/base.sh
+++ b/templates/Debian-7.3.0-i386-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev

--- a/templates/Debian-7.4.0-amd64-netboot/base.sh
+++ b/templates/Debian-7.4.0-amd64-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev

--- a/templates/Debian-7.4.0-i386-netboot/base.sh
+++ b/templates/Debian-7.4.0-i386-netboot/base.sh
@@ -1,4 +1,5 @@
 # Update the box
+export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev


### PR DESCRIPTION
A recent openssl update in Debian 7 brings up an interactive prompt which hangs indefinitely, causing `veewee vbox build` to timeout (presumably `libssl-dev` https://github.com/jedi4ever/veewee/blob/master/templates/Debian-7.4.0-amd64-netboot/base.sh#L4)
![screen shot 2014-04-09 at 18 23 56](https://cloud.githubusercontent.com/assets/1644105/2660233/205edd18-c01d-11e3-853c-573a9e0917a1.png)
I've checked Debian-7.0-i386-netboot and Debian-7.4.0-amd64-netboot, the problem occurs in both.

This PR sets an environment variable which should force the default action to be taken without prompting.
