### PR TITLE
[Minor] Force delete udev rules file to suppress warnings.

### DIFF
--- a/templates/ubuntu-14.04-server-amd64/cleanup.sh
+++ b/templates/ubuntu-14.04-server-amd64/cleanup.sh
@@ -7,7 +7,7 @@ echo "cleaning up dhcp leases"
 rm /var/lib/dhcp/*
 
 echo "cleaning up udev rules"
-rm /etc/udev/rules.d/70-persistent-net.rules
+rm -f /etc/udev/rules.d/70-persistent-net.rules
 mkdir /etc/udev/rules.d/70-persistent-net.rules
 rm -rf /dev/.udev/
 rm /lib/udev/rules.d/75-persistent-net-generator.rules


### PR DESCRIPTION
Signed-off-by: Gregor Zurowski gregor@zurowski.org
