### PR TITLE
Fix VMWare Fusion 6 compatability

### DIFF
--- a/lib/veewee/provider/vmfusion/box/template.vmx.erb
+++ b/lib/veewee/provider/vmfusion/box/template.vmx.erb
@@ -96,7 +96,7 @@ sound.startConnected = "FALSE"
 RemoteDisplay.vnc.enabled = "TRUE"
 RemoteDisplay.vnc.port = "<%= vnc_port %>"
 <% if enable_hypervisor_support == true %>vhv.enable = "TRUE"<% end %>
-<% if fusion_version.start_with?('5.') %>bios.bootOrder = "hdd,CDROM"<% end %>
+<% if fusion_version.start_with?('5.') or fusion_version.start_with?('6.') %>bios.bootOrder = "hdd,CDROM"<% end %>
 <% unless vmdk_file.nil? %>
 scsi0:2.present = "TRUE"
 scsi0:2.fileName = "<%= vmdk_file %>"


### PR DESCRIPTION
Make vmx file generation compatible with the latest VMWare Fusion 6. 

We still have to specify boot order for Fusion 6*, otherwise some OS wouldn't load. Could be easily reproduced with windows-2008R2-serverstandard-amd64-winrm, without bootOrder the VM wouldn't start installation.
