### PR TITLE
Fix VirtualBox Addition installation to support VirtualBox >= 4.2.2

### DIFF
--- a/templates/windows-2008R1-serverweb-amd64/install-vbox-guest.bat
+++ b/templates/windows-2008R1-serverweb-amd64/install-vbox-guest.bat
@@ -1,2 +1,7 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
-e:\VBoxWindowsAdditions-amd64.exe /S
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
+cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
+cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"

--- a/templates/windows-2008R1-serverweb-i386/install-vbox-guest.bat
+++ b/templates/windows-2008R1-serverweb-i386/install-vbox-guest.bat
@@ -1,2 +1,7 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
-e:\VBoxWindowsAdditions-x86.exe /S
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
+cmd /c e:\VBoxWindowsAdditions-x86.exe /S
+cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"

--- a/templates/windows-2008R1-serverwebcore-amd64/install-vbox-guest.bat
+++ b/templates/windows-2008R1-serverwebcore-amd64/install-vbox-guest.bat
@@ -1,2 +1,7 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
-e:\VBoxWindowsAdditions-amd64.exe /S
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
+cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
+cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"

--- a/templates/windows-2008R2-serverstandard-amd64-winrm/install-vbox.bat
+++ b/templates/windows-2008R2-serverstandard-amd64-winrm/install-vbox.bat
@@ -1,2 +1,7 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
 cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
+cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"

--- a/templates/windows-2008R2-serverweb-amd64/install-vbox-guest.bat
+++ b/templates/windows-2008R2-serverweb-amd64/install-vbox-guest.bat
@@ -1,2 +1,8 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
-e:\VBoxWindowsAdditions-amd64.exe /S
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
+cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
+cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"
+

--- a/templates/windows-2008R2-serverwebcore-amd64/install-vbox-guest.bat
+++ b/templates/windows-2008R2-serverwebcore-amd64/install-vbox-guest.bat
@@ -1,2 +1,7 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
-e:\VBoxWindowsAdditions-amd64.exe /S
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
+cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
+cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"

--- a/templates/windows-2012-serverstandard-amd64/install-vbox.bat
+++ b/templates/windows-2012-serverstandard-amd64/install-vbox.bat
@@ -1,4 +1,8 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
 cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
 cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"
 

--- a/templates/windows-2012R2-serverdatacenter-amd64/install-vbox.bat
+++ b/templates/windows-2012R2-serverdatacenter-amd64/install-vbox.bat
@@ -1,4 +1,8 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
 cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
 cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"
 

--- a/templates/windows-7-enterprise-amd64-winrm/install-vbox.bat
+++ b/templates/windows-7-enterprise-amd64-winrm/install-vbox.bat
@@ -1,4 +1,7 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
 cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
-
-shutdown /r /t 2 /c "Install Virtualbox Guest Additions Reboot" /f /d p:4:1
+cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"

--- a/templates/windows-7-enterprise-amd64/install-vbox-guest.bat
+++ b/templates/windows-7-enterprise-amd64/install-vbox-guest.bat
@@ -1,2 +1,7 @@
-cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
-e:\VBoxWindowsAdditions-amd64.exe /S
+if exist e:\cert\VBoxCertUtil (
+   cmd /c e:\cert\VBoxCertUtil add-trusted-publisher e:\cert\oracle-vbox.cer --root e:\cert\oracle-vbox.cer
+) else (
+   cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
+)
+cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
+cmd /c shutdown.exe /r /t 5 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"


### PR DESCRIPTION
Windows VirtualBox scripts were failing due to a change of the way you need to upload the oracle certs. Tested and working now
