### PR TITLE
Fix a bug when build kvm box.

### DIFF
--- a/templates/CentOS-6.5-x86_64-netboot/ks.cfg
+++ b/templates/CentOS-6.5-x86_64-netboot/ks.cfg
@@ -23,6 +23,8 @@ reboot
 
 %packages --nobase
 @core
+openssh-clients
+openssh-server
 %end
 
 %post


### PR DESCRIPTION
# The error message is like:

```
    Transferring /tmp/.veewee_version20140523-4519-1mh5ulu to .veewee_version
    Error transfering file /tmp/.veewee_version20140523-4519-1mh5ulu failed, possible not enough permissions to write? SCP did not finish successfully (127):
    SCP did not finish successfully (127):
```
# 

Turns out the guest machine doesn't have `scp` installed.
