### PR TITLE
Fix / refactor Oracle Linux 5 and 6 templates

### DIFF
--- a/templates/OracleLinux-5.10-i386-DVD/base.sh
+++ b/templates/OracleLinux-5.10-i386-DVD/base.sh
@@ -4,8 +4,7 @@ source ./proxy.sh
 
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
-cd /etc/yum.repos.d
-wget https://public-yum.oracle.com/public-yum-el5.repo
+wget http://public-yum.oracle.com/public-yum-el5.repo -O /etc/yum.repos.d/public-yum-el5.repo
 
 cd /tmp
 wget http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm
@@ -18,9 +17,3 @@ rm -f /tmp/epel-release-5-4.noarch.rpm
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
 sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network
-
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` \
-  kernel-uek-devel-`uname -r` zlib-devel openssl-devel \
-  readline-devel sqlite-devel perl wget curl bzip2 dkms
-
-yum -y update

--- a/templates/OracleLinux-5.10-i386-DVD/ks.cfg
+++ b/templates/OracleLinux-5.10-i386-DVD/ks.cfg
@@ -16,12 +16,32 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-auth --useshadow --enablemd5
 firstboot --disabled
 reboot
 
 %packages --ignoremissing
 @core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+deltarpm
+yum-utils
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware

--- a/templates/OracleLinux-5.10-i386-DVD/ruby.sh
+++ b/templates/OracleLinux-5.10-i386-DVD/ruby.sh
@@ -2,7 +2,7 @@
 
 source ./proxy.sh
 
-RUBY_VERSION="ruby-1.9.3-p484"
+RUBY_VERSION="ruby-1.9.3-p547"
 RUBY_SOURCE="http://ftp.ruby-lang.org/pub/ruby/1.9/${RUBY_VERSION}.tar.gz"
 LIBYAML_VERSION="yaml-0.1.5"
 LIBYAML_SOURCE="http://pyyaml.org/download/libyaml/${LIBYAML_VERSION}.tar.gz"

--- a/templates/OracleLinux-5.10-x86_64-DVD/base.sh
+++ b/templates/OracleLinux-5.10-x86_64-DVD/base.sh
@@ -4,8 +4,7 @@ source ./proxy.sh
 
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
-cd /etc/yum.repos.d
-wget https://public-yum.oracle.com/public-yum-el5.repo
+wget http://public-yum.oracle.com/public-yum-el5.repo -O /etc/yum.repos.d/public-yum-el5.repo
 
 cd /tmp
 wget http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm
@@ -18,9 +17,3 @@ rm -f /tmp/epel-release-5-4.noarch.rpm
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
 sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network
-
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` \
-  kernel-uek-devel-`uname -r` zlib-devel openssl-devel \
-  readline-devel sqlite-devel perl wget curl bzip2 dkms
-
-yum -y update

--- a/templates/OracleLinux-5.10-x86_64-DVD/ks.cfg
+++ b/templates/OracleLinux-5.10-x86_64-DVD/ks.cfg
@@ -16,12 +16,32 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-auth --useshadow --enablemd5
 firstboot --disabled
 reboot
 
 %packages --ignoremissing
 @core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+deltarpm
+yum-utils
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware

--- a/templates/OracleLinux-5.10-x86_64-DVD/ruby.sh
+++ b/templates/OracleLinux-5.10-x86_64-DVD/ruby.sh
@@ -2,7 +2,7 @@
 
 source ./proxy.sh
 
-RUBY_VERSION="ruby-1.9.3-p484"
+RUBY_VERSION="ruby-1.9.3-p547"
 RUBY_SOURCE="http://ftp.ruby-lang.org/pub/ruby/1.9/${RUBY_VERSION}.tar.gz"
 LIBYAML_VERSION="yaml-0.1.5"
 LIBYAML_SOURCE="http://pyyaml.org/download/libyaml/${LIBYAML_VERSION}.tar.gz"

--- a/templates/OracleLinux-5.9-i386-DVD/base.sh
+++ b/templates/OracleLinux-5.9-i386-DVD/base.sh
@@ -4,8 +4,7 @@ source ./proxy.sh
 
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
-cd /etc/yum.repos.d
-wget https://public-yum.oracle.com/public-yum-el5.repo
+wget http://public-yum.oracle.com/public-yum-el5.repo -O /etc/yum.repos.d/public-yum-el5.repo
 
 cd /tmp
 wget http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm
@@ -18,9 +17,3 @@ rm -f /tmp/epel-release-5-4.noarch.rpm
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
 sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network
-
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` \
-  kernel-uek-devel-`uname -r` zlib-devel openssl-devel \
-  readline-devel sqlite-devel perl wget curl bzip2 dkms
-
-yum -y update

--- a/templates/OracleLinux-5.9-i386-DVD/ks.cfg
+++ b/templates/OracleLinux-5.9-i386-DVD/ks.cfg
@@ -16,12 +16,32 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-auth --useshadow --enablemd5
 firstboot --disabled
 reboot
 
 %packages --ignoremissing
 @core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+deltarpm
+yum-utils
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware

--- a/templates/OracleLinux-5.9-i386-DVD/ruby.sh
+++ b/templates/OracleLinux-5.9-i386-DVD/ruby.sh
@@ -2,9 +2,9 @@
 
 source ./proxy.sh
 
-RUBY_VERSION="ruby-1.9.3-p448"
+RUBY_VERSION="ruby-1.9.3-p547"
 RUBY_SOURCE="http://ftp.ruby-lang.org/pub/ruby/1.9/${RUBY_VERSION}.tar.gz"
-LIBYAML_VERSION="yaml-0.1.4"
+LIBYAML_VERSION="yaml-0.1.5"
 LIBYAML_SOURCE="http://pyyaml.org/download/libyaml/${LIBYAML_VERSION}.tar.gz"
 
 yum install -y readline-devel ncurses-devel gdbm-devel tcl-devel \

--- a/templates/OracleLinux-5.9-x86_64-DVD/base.sh
+++ b/templates/OracleLinux-5.9-x86_64-DVD/base.sh
@@ -4,8 +4,7 @@ source ./proxy.sh
 
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
-cd /etc/yum.repos.d
-wget https://public-yum.oracle.com/public-yum-el5.repo
+wget http://public-yum.oracle.com/public-yum-el5.repo -O /etc/yum.repos.d/public-yum-el5.repo
 
 cd /tmp
 wget http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm
@@ -18,9 +17,3 @@ rm -f /tmp/epel-release-5-4.noarch.rpm
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
 sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network
-
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` \
-  kernel-uek-devel-`uname -r` zlib-devel openssl-devel \
-  readline-devel sqlite-devel perl wget curl bzip2 dkms
-
-yum -y update

--- a/templates/OracleLinux-5.9-x86_64-DVD/ks.cfg
+++ b/templates/OracleLinux-5.9-x86_64-DVD/ks.cfg
@@ -16,12 +16,32 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-auth --useshadow --enablemd5
 firstboot --disabled
 reboot
 
 %packages --ignoremissing
 @core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+deltarpm
+yum-utils
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware

--- a/templates/OracleLinux-5.9-x86_64-DVD/ruby.sh
+++ b/templates/OracleLinux-5.9-x86_64-DVD/ruby.sh
@@ -2,9 +2,9 @@
 
 source ./proxy.sh
 
-RUBY_VERSION="ruby-1.9.3-p448"
+RUBY_VERSION="ruby-1.9.3-p547"
 RUBY_SOURCE="http://ftp.ruby-lang.org/pub/ruby/1.9/${RUBY_VERSION}.tar.gz"
-LIBYAML_VERSION="yaml-0.1.4"
+LIBYAML_VERSION="yaml-0.1.5"
 LIBYAML_SOURCE="http://pyyaml.org/download/libyaml/${LIBYAML_VERSION}.tar.gz"
 
 yum install -y readline-devel ncurses-devel gdbm-devel tcl-devel \

--- a/templates/OracleLinux-6.4-i386-DVD/base.sh
+++ b/templates/OracleLinux-6.4-i386-DVD/base.sh
@@ -5,8 +5,7 @@ source ./proxy.sh
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
 cd /etc/yum.repos.d
-wget https://public-yum.oracle.com/public-yum-ol6.repo
-yum -y update
+wget http://public-yum.oracle.com/public-yum-ol6.repo
 
 cd /tmp
 wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
@@ -19,7 +18,3 @@ rm -f /tmp/epel-release-6-8.noarch.rpm
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
 sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network
-
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` \
-  kernel-uek-devel-`uname -r` zlib-devel openssl-devel \
-  readline-devel sqlite-devel perl wget curl bzip2 dkms

--- a/templates/OracleLinux-6.4-i386-DVD/ks.cfg
+++ b/templates/OracleLinux-6.4-i386-DVD/ks.cfg
@@ -17,15 +17,35 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-auth --useshadow --enablemd5
 firstboot --disabled
 reboot
 
 %packages --ignoremissing
 @core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+yum-utils
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware
+%end
 
 %post --log=/root/ks-postinstall.log
 /usr/sbin/groupadd veewee

--- a/templates/OracleLinux-6.4-i386-DVD/puppet.sh
+++ b/templates/OracleLinux-6.4-i386-DVD/puppet.sh
@@ -3,8 +3,8 @@
 source ./proxy.sh
 
 cd /tmp
-wget https://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-7.noarch.rpm
-rpm -ivh puppetlabs-release-6-7.noarch.rpm
-rm -f /tmp/puppetlabs-release-6-7.noarch.rpm
+wget http://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-10.noarch.rpm
+rpm -ivh puppetlabs-release-6-10.noarch.rpm
+rm -f /tmp/puppetlabs-release-6-10.noarch.rpm
 
 yum -y install puppet facter

--- a/templates/OracleLinux-6.4-x86_64-DVD/base.sh
+++ b/templates/OracleLinux-6.4-x86_64-DVD/base.sh
@@ -5,8 +5,7 @@ source ./proxy.sh
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
 cd /etc/yum.repos.d
-wget https://public-yum.oracle.com/public-yum-ol6.repo
-yum -y update
+wget http://public-yum.oracle.com/public-yum-ol6.repo
 
 cd /tmp
 wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
@@ -19,7 +18,3 @@ rm -f /tmp/epel-release-6-8.noarch.rpm
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
 sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network
-
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` \
-  kernel-uek-devel-`uname -r` zlib-devel openssl-devel \
-  readline-devel sqlite-devel perl wget curl bzip2 dkms

--- a/templates/OracleLinux-6.4-x86_64-DVD/ks.cfg
+++ b/templates/OracleLinux-6.4-x86_64-DVD/ks.cfg
@@ -17,15 +17,35 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-auth --useshadow --enablemd5
 firstboot --disabled
 reboot
 
 %packages --ignoremissing
 @core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+yum-utils
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware
+%end
 
 %post --log=/root/ks-postinstall.log
 /usr/sbin/groupadd veewee

--- a/templates/OracleLinux-6.4-x86_64-DVD/puppet.sh
+++ b/templates/OracleLinux-6.4-x86_64-DVD/puppet.sh
@@ -3,8 +3,8 @@
 source ./proxy.sh
 
 cd /tmp
-wget https://yum.puppetlabs.com/el/6/products/x86_64/puppetlabs-release-6-7.noarch.rpm
-rpm -ivh puppetlabs-release-6-7.noarch.rpm
-rm -f /tmp/puppetlabs-release-6-7.noarch.rpm
+wget http://yum.puppetlabs.com/el/6/products/x86_64/puppetlabs-release-6-10.noarch.rpm
+rpm -ivh puppetlabs-release-6-10.noarch.rpm
+rm -f /tmp/puppetlabs-release-6-10.noarch.rpm
 
 yum -y install puppet facter

--- a/templates/OracleLinux-6.5-i386-DVD/base.sh
+++ b/templates/OracleLinux-6.5-i386-DVD/base.sh
@@ -4,22 +4,17 @@ source ./proxy.sh
 
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
-cd /etc/yum.repos.d
-wget https://public-yum.oracle.com/public-yum-ol6.repo
-yum -y update
+wget http://public-yum.oracle.com/public-yum-ol6.repo -O /etc/yum.repos.d/public-yum-ol6.repo
+# UEK R3 Latest Channel NOT enabled by default
 
 cd /tmp
-wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 rpm -ivh epel-release-6-8.noarch.rpm
 rm -f /tmp/epel-release-6-8.noarch.rpm
 # Not flexible to switch between direct Internet access and behind firewall
 # --httpproxy HOST --httpport PORT
-# rpm -ivh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+# rpm -ivh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
 sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network
-
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` \
-  kernel-uek-devel-`uname -r` zlib-devel openssl-devel \
-  readline-devel sqlite-devel perl wget curl bzip2 dkms

--- a/templates/OracleLinux-6.5-i386-DVD/ks.cfg
+++ b/templates/OracleLinux-6.5-i386-DVD/ks.cfg
@@ -17,15 +17,35 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-auth --useshadow --enablemd5
 firstboot --disabled
 reboot
 
 %packages --ignoremissing
 @core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+yum-utils
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware
+%end
 
 %post --log=/root/ks-postinstall.log
 /usr/sbin/groupadd veewee

--- a/templates/OracleLinux-6.5-i386-DVD/puppet.sh
+++ b/templates/OracleLinux-6.5-i386-DVD/puppet.sh
@@ -3,8 +3,8 @@
 source ./proxy.sh
 
 cd /tmp
-wget https://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-7.noarch.rpm
-rpm -ivh puppetlabs-release-6-7.noarch.rpm
-rm -f /tmp/puppetlabs-release-6-7.noarch.rpm
+wget http://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-10.noarch.rpm
+rpm -ivh puppetlabs-release-6-10.noarch.rpm
+rm -f /tmp/puppetlabs-release-6-10.noarch.rpm
 
 yum -y install puppet facter

--- a/templates/OracleLinux-6.5-x86_64-DVD/base.sh
+++ b/templates/OracleLinux-6.5-x86_64-DVD/base.sh
@@ -4,9 +4,8 @@ source ./proxy.sh
 
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
-cd /etc/yum.repos.d
-wget https://public-yum.oracle.com/public-yum-ol6.repo
-yum -y update
+wget http://public-yum.oracle.com/public-yum-ol6.repo -O /etc/yum.repos.d/public-yum-ol6.repo
+# UEK R3 Latest Channel NOT enabled by default
 
 cd /tmp
 wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
@@ -19,7 +18,3 @@ rm -f /tmp/epel-release-6-8.noarch.rpm
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
 sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network
-
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` \
-  kernel-uek-devel-`uname -r` zlib-devel openssl-devel \
-  readline-devel sqlite-devel perl wget curl bzip2 dkms

--- a/templates/OracleLinux-6.5-x86_64-DVD/ks.cfg
+++ b/templates/OracleLinux-6.5-x86_64-DVD/ks.cfg
@@ -17,15 +17,35 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-auth --useshadow --enablemd5
 firstboot --disabled
 reboot
 
 %packages --ignoremissing
 @core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+yum-utils
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware
+%end
 
 %post --log=/root/ks-postinstall.log
 /usr/sbin/groupadd veewee

--- a/templates/OracleLinux-6.5-x86_64-DVD/puppet.sh
+++ b/templates/OracleLinux-6.5-x86_64-DVD/puppet.sh
@@ -3,8 +3,8 @@
 source ./proxy.sh
 
 cd /tmp
-wget https://yum.puppetlabs.com/el/6/products/x86_64/puppetlabs-release-6-7.noarch.rpm
-rpm -ivh puppetlabs-release-6-7.noarch.rpm
-rm -f /tmp/puppetlabs-release-6-7.noarch.rpm
+wget http://yum.puppetlabs.com/el/6/products/x86_64/puppetlabs-release-6-10.noarch.rpm
+rpm -ivh puppetlabs-release-6-10.noarch.rpm
+rm -f /tmp/puppetlabs-release-6-10.noarch.rpm
 
 yum -y install puppet facter


### PR DESCRIPTION
Recently I've found some issues with the templates (Oracle Linux 5.9, 5.10, 6.4, 6.5) contributed by myself when using Veewee to Build Oracle Linux 6.5 and 5.10 Vagrant base boxes.
1. VirtualBox Additions installation could fail due to booting (reboot) into a newer version of the kernel (caused by `yum -y update` in `base.sh`). This will cause `vboxsf` validation failure. Issue fixed by moving the initial provisioning into Kickstart file, which is much more controllable and reliable when using DVD as install media.
2. Since RHEL 6, Kickstart syntaxes have changed. In the Kickstart file `ks.cfg`, `%package` MUST end with `%end`. EL 6 Kickstart installation still works without it BUT will certainly fail when using the same `ks.cfg` to install EL 7.
3. Removed duplicated `-auth --useshadow --enablemd5` from `ks.cfg`.
4. Some minor updates.
