### PR TITLE
Fine tune Solaris 10 template

### DIFF
--- a/templates/solaris-10-ga-x86/README.md
+++ b/templates/solaris-10-ga-x86/README.md
@@ -22,17 +22,15 @@
    It also shuts down the box in the process, to allow packaging.
 
 3. Export the basebox and use it freely.
-   
-   To to this, from the definition folder execute (or provide the correct paths to the Vagrantfile.pkg):
-   
+
    ```
-   vagrant package --vagrantfile Vagrantfile.pkg --base 'vagrant-solaris10' --output 'vagrant-solaris10.box'
+   veewee vbox export 'vagrant-solaris10'
    ```
 
    You may find some issues if you run this command from your veewee installation, due to the relationship between vagrant and veewee.
    It's advisable to switch to the system's ruby (`rvm use system`) and running the command directly from the definition folder.
-   
-   
+
+
 #Migration to VMWare
 VirtualBox VMs can easily be migrated to VMWare but, in the case of Solaris 10 (at least), some differences regarding the use of IDE and SCSI render the migrated box unusable.
 

--- a/templates/solaris-10-ga-x86/chef.sh
+++ b/templates/solaris-10-ga-x86/chef.sh
@@ -1,10 +1,7 @@
 # Chef needs these
 /opt/csw/bin/pkgutil -y -i CSWgmake
 /opt/csw/bin/pkgutil -y -i CSWgcc4g++ CSWgcc4core
+/opt/csw/bin/pkgutil -y -i CSWcurl
 
-# These are needed to get a compiler working
-# Mainly because chef depends on compiling some native gems
-PATH=/opt/csw/bin:/opt/csw/gnu/:/opt/csw/gcc4/bin:$PATH
-export PATH
-
-/opt/csw/bin/gem install chef  --no-ri --no-rdoc
+# Install Chef
+curl -L https://www.opscode.com/chef/install.sh | bash

--- a/templates/solaris-10-ga-x86/definition.rb
+++ b/templates/solaris-10-ga-x86/definition.rb
@@ -1,8 +1,9 @@
 Veewee::Definition.declare({
   :cpu_count => '1', :memory_size=> '768',
   #Disk size needs to be 12Gig +
-  :disk_size => '65140', :disk_format => 'VDI', :hostiocache => 'off', :hwvirtex => 'on',
-  :os_type_id => 'Solaris_64',
+  :disk_size => '65140', :disk_format => 'VDI', :hostiocache => 'off',
+  :virtualbox => { :vm_options => [ "hwvirtex" => "on" ] },
+  :os_type_id => 'OpenSolaris_64',
   :iso_file => "sol-10-u11-ga-x86-dvd.iso",
   :iso_src => "",
   :iso_download_instructions => "- You need to download this manually as there is no automated way to do it\n"+
@@ -12,7 +13,7 @@ Veewee::Definition.declare({
     "- For other version: changed the iso filename+checksum\n",
   :iso_md5 => "aae1452bb3d56baa3dcb8866ce7e4a08",
   :iso_download_timeout => 1000,
-  :boot_wait => "10", :boot_cmd_sequence => [ 
+  :boot_wait => "10", :boot_cmd_sequence => [
     'e',
     'e',
     '<Backspace>'*22,

--- a/templates/solaris-10-ga-x86/postinstall.sh
+++ b/templates/solaris-10-ga-x86/postinstall.sh
@@ -10,6 +10,10 @@ PATH=/usr/bin:/usr/sbin:$PATH
 export PATH
 
 yes|/usr/sbin/pkgadd -d http://mirror.opencsw.org/opencsw/pkgutil-`uname -p`.pkg all
+
+# Uncomment this and pick a fast mirror from http://mirror.opencsw.org/status/
+# echo "mirror=http://www.grangefields.co.uk/mirrors/csw/testing" >> /etc/opt/csw/pkgutil.conf
+
 /opt/csw/bin/pkgutil -U
 
 # get 'sudo'
@@ -48,7 +52,7 @@ echo "LookupClientHostnames=no" >> /etc/ssh/sshd_config
 #
 ## no solaris2.11 .... mkheaders here ! needs some fixing ??
 ## /opt/csw/gcc4/libexec/gcc/i386-pc-solaris2.10/4.3.3/install-tools/mkheaders
-#/opt/csw/gcc4/libexec/gcc/i386-pc-solaris2.8/4.3.3/install-tools/mkheaders 
+#/opt/csw/gcc4/libexec/gcc/i386-pc-solaris2.8/4.3.3/install-tools/mkheaders
 #
 #/opt/csw/sbin/alternatives --display rbconfig18
 #/opt/csw/sbin/alternatives --set rbconfig18 /opt/csw/lib/ruby/1.8/i386-solaris2.9/rbconfig.rb.gcc4


### PR DESCRIPTION
- move :hwvirtex into :vm_options
- correct os_type_id
- use curl/bash method to install chef in order to prevent gem compile
  issue (fix #976)
- modify instruction to use `veewee box export` instead of raw Vagrant
  commands

(also removed some trailing spaces...)
