### PR TITLE
Fix Windows 8.1 compatibility

### DIFF
--- a/lib/veewee/provider/virtualbox/box.rb
+++ b/lib/veewee/provider/virtualbox/box.rb
@@ -28,34 +28,35 @@ module Veewee
   module Provider
     module Virtualbox
       class Box < Veewee::Provider::Core::Box
-
         include ::Veewee::Provider::Virtualbox::BoxCommand
 
-        def initialize(name,env)
+        def initialize(name, env)
           @vboxcmd = self.class.determine_vboxcmd
           super(name, env)
         end
 
         def self.windows_vboxcmd
           # based on Vagrant/plugins/providers/virtualbox/driver/base.rb
-          if OS.windows? && ENV.has_key?("VBOX_INSTALL_PATH")
-            ENV["VBOX_INSTALL_PATH"].split(File::PATH_SEPARATOR).each do |path|
-              vboxmanage = File.join(path,"VBoxManage.exe")
-              return "\"#{vboxmanage}\"" if File.file?(vboxmanage)
+          if OS.windows?
+            if ENV.key?('VBOX_INSTALL_PATH') ||
+               ENV.key?('VBOX_MSI_INSTALL_PATH')
+              path = ENV['VBOX_INSTALL_PATH'] || ENV['VBOX_MSI_INSTALL_PATH']
+              path.split(File::PATH_SEPARATOR).each do |single|
+                vboxmanage = File.join(single, 'VBoxManage.exe')
+                return "\"#{vboxmanage}\"" if File.file?(vboxmanage)
+              end
             end
           end
           nil
         end
 
         def self.default_vboxcmd
-          "VBoxManage"
+          'VBoxManage'
         end
 
         def self.determine_vboxcmd
           @command ||= windows_vboxcmd || default_vboxcmd
         end
-
-
       end # End Class
     end # End Module
   end # End Module

--- a/lib/veewee/provider/virtualbox/box/export_vagrant.rb
+++ b/lib/veewee/provider/virtualbox/box/export_vagrant.rb
@@ -110,7 +110,7 @@ module Veewee
             end
 
             ui.info "Exporting the box"
-            command = "#{@vboxcmd} export \"#{name}\" --output #{File.join(tmp_dir,'box.ovf')}"
+            command = "#{@vboxcmd} export \"#{name}\" --output \"#{File.join(tmp_dir,'box.ovf')}\""
             env.logger.debug("Command: #{command}")
             shell_exec(command, {:mute => false})
 


### PR DESCRIPTION
- Use `VBOX_MSI_INSTALL_PATH` environment variable (Windows)
- Double quote the output path to account for spaces (Windows)
