### PR TITLE
Make special scancodes keys case-insensitive

### DIFF
--- a/lib/veewee/provider/core/helper/scancode.rb
+++ b/lib/veewee/provider/core/helper/scancode.rb
@@ -70,7 +70,7 @@ module Veewee
             until thestring.length == 0
               nospecial=true;
               @@special_keys.keys.each { |key|
-                if thestring.start_with?(key)
+                if thestring.match(/^#{key}/i)
                   #take thestring
                   #check if it starts with a special key + pop special string
                   keycodes=keycodes+@@special_keys[key]+' ';


### PR DESCRIPTION
I've always been annoyed that `boot_cmd_sequence` requires special keys to be case-sensitive.

For example: `<wait>, <WAIT> and <WaiT>` were not being recognized as special keys.

This tiny pull request fixes that, although could potentially introduce breaking changes for people who were never expecting case-insensitive special keys.. :panda_face: 
