### PR TITLE
Fix windows 2012 product key definition for unattended installation

### DIFF
--- a/templates/windows-2012-serverstandard-amd64/Autounattend.xml
+++ b/templates/windows-2012-serverstandard-amd64/Autounattend.xml
@@ -37,7 +37,8 @@
 
             <UserData>
               <!-- Product Key from http://technet.microsoft.com/en-us/library/ff793406.aspx -->
-                <ProductKey>YC6KT-GKW9T-YTKYR-T4X34-R7VHC
+                <ProductKey>
+                    <Key>YC6KT-GKW9T-YTKYR-T4X34-R7VHC</Key>
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
 

--- a/templates/windows-2012R2-serverdatacenter-amd64/Autounattend.xml
+++ b/templates/windows-2012R2-serverdatacenter-amd64/Autounattend.xml
@@ -37,7 +37,8 @@
 
             <UserData>
               <!-- Product Key from http://technet.microsoft.com/en-us/library/ff793406.aspx -->
-                <ProductKey>W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9
+                <ProductKey>
+                    <Key>W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9</Key>
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
 


### PR DESCRIPTION
otherwise you get a "Windows cannot read the <Product Key> setting from the unattend answer file" error
@see http://technet.microsoft.com/en-US/library/cc721925(v=ws.10).aspx
