### PR TITLE
Fixing ssh_key issues with pull request 762

### DIFF
--- a/lib/veewee/provider/core/box/ssh.rb
+++ b/lib/veewee/provider/core/box/ssh.rb
@@ -15,8 +15,7 @@ module Veewee
 
           if (options[:interactive]==true)
             unless host_ip.nil? || host_ip==""
-              raise Veewee::Error,"No ssh command was given" if command.nil?
-              ssh_command="ssh #{ssh_commandline_options(options)} #{host_ip} #{Shellwords.escape command}"
+              ssh_command="ssh #{ssh_commandline_options(options)} #{host_ip} #{Shellwords.escape(command) if command}"
 
               fg_exec(ssh_command,options)
 


### PR DESCRIPTION
ssh_key_to_a should be calling definition.ssh_key since the variable ssh_key"
is not defined until lower in the loop. Also, in the loop we should be refering
to the variable from the array created by ssh_key_to_a when figuring out
a path.

I also noticed that if no ssh command was given, a nasty shellescape error was
given, so we should raise an error if that is the case.
