### PR TITLE
VirtualBox build fails, `handle_kickstart': undefined method `kickstartfiles'

### DIFF
--- a/lib/veewee/provider/core/box/build.rb
+++ b/lib/veewee/provider/core/box/build.rb
@@ -225,7 +225,7 @@ module Veewee
 
           case definition.kickstart_file
           when Array  then kickstartfiles = definition.kickstart_file
-          when String then kickstartfiles = definition.kickstartfiles.split
+          when String then kickstartfiles = definition.kickstart_file.split
           when nil    then kickstartfiles = []
           else raise "Do not know how to handle kickstart_file: #{kickstart_file.inspect}"
           end


### PR DESCRIPTION
It looks like there was a typo in c6d772dd5db8b4d3e703a63a5e9b71e01a3afac1. Building with VirtualBox:

```
...
$ veewee vbox build kickstart
Downloading vbox guest additions iso v 4.3.18 - http://download.virtualbox.org/virtualbox/4.3.18/VBoxGuestAdditions_4.3.18.iso
Checking if isofile VBoxGuestAdditions_4.3.18.iso already exists.
Full path: /Users/simon/work/veewee/iso/VBoxGuestAdditions_4.3.18.iso
Moving /var/folders/zp/l27xv5sd4f9fsbfkyqtdcjgr0000gp/T/open-uri20141020-72316-14dgtbx to /Users/simon/work/veewee/iso/VBoxGuestAdditions_4.3.18.iso
Building Box kickstart with Definition kickstart:
- debug : false
- cwd : /Users/simon/work/veewee
- force : false
- nogui : false
- auto : false
- checksum : false
- redirectconsole : false
- postinstall_include : []
- postinstall_exclude : []
- skip_to_postinstall : false

The isofile debian-7.6.0-amd64-netinst.iso already exists.
Creating vm kickstart : 256M - 1 CPU - Debian_64
Creating new harddrive of size 10140, format VDI, variant Standard
Attaching disk: /Users/simon/VirtualBox VMs/kickstart/kickstart1.vdi
Mounting cdrom: /Users/simon/work/veewee/iso/debian-7.6.0-amd64-netinst.iso
Mounting guest additions: /Users/simon/work/veewee/iso/VBoxGuestAdditions_4.3.18.iso
Finding unused TCP port in range: 7222 - 7262
Selected TCP port 7222
Finding unused TCP port in range: 7222 - 7262
Selected TCP port 7222
Waiting 10 seconds for the machine to boot
Finding unused TCP port in range: 7122 - 7199
Selected TCP port 7122
/Users/simon/work/veewee/lib/veewee/provider/core/box/build.rb:228:in `handle_kickstart': undefined method `kickstartfiles' for #<Veewee::Definition:0x007fa057c90168> (NoMethodError)
    from /Users/simon/work/veewee/lib/veewee/provider/core/box/build.rb:82:in `kickstart'
    from /Users/simon/work/veewee/lib/veewee/provider/core/box/build.rb:113:in `build'
    from /Users/simon/work/veewee/lib/veewee/provider/virtualbox/box/build.rb:10:in `build'
    from /Users/simon/work/veewee/lib/veewee/command/vbox.rb:22:in `build'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/gems/thor-0.19.1/lib/thor/invocation.rb:115:in `invoke'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/gems/thor-0.19.1/lib/thor.rb:235:in `block in subcommand'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /Users/simon/work/veewee/bin/veewee:24:in `<top (required)>'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/bin/veewee:23:in `load'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/bin/veewee:23:in `<main>'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/bin/ruby_executable_hooks:15:in `eval'
    from /Users/simon/.rvm/gems/ruby-1.9.3-p547/bin/ruby_executable_hooks:15:in `<main>'
...
```

I think `definition.kickstartfiles` should be `definition.kickstart_file`.
