### PR TITLE
Update installation.md

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -33,7 +33,7 @@ Installing Veewee without a Ruby version manager is **NOT** recommended:
 
 With RVM already installed (see [Requirements](requirements.md)), ensure a ruby version that's supported by Veewee is available on your machine:
 
-    $ rvm install 1.9.2
+    $ rvm install ruby
 
 Clone the veewee project from source:
 
@@ -43,7 +43,7 @@ Clone the veewee project from source:
 
 Set the local gemset and ruby version within the current directory:
 
-    $ rvm use 1.9.2@veewee --create
+    $ rvm use ruby@veewee --create
 
 Run `bundle install` to install Gemfile dependencies for our local gemset:
 


### PR DESCRIPTION
12:08 < mumm_ra> Am I supposed to use ruby 1.9.2 as shown ^^
12:09 < mumm_ra> Gem::InstallError: gem-content requires Ruby version >= 1.9.3.
12:09 < mumm_ra> An error occurred while installing gem-content (1.0.0), and Bundler cannot continue.
12:09 < mumm_ra> Make sure that `gem install gem-content -v '1.0.0'` succeeds before bundling.
12:09 < mumm_ra> when I bundle install as suggested
12:09 < mumm_ra> bundle install
12:11 < mpapis> mumm_ra, yep please use newer ruby, open a ticket to update this doc
