### PR TITLE
Added bzip2 to CentOS-7.0-1406-x86_64-netinstall base.sh. 

### DIFF
--- a/templates/CentOS-7.0-1406-x86_64-netinstall/base.sh
+++ b/templates/CentOS-7.0-1406-x86_64-netinstall/base.sh
@@ -10,7 +10,7 @@ enabled=1
 gpgcheck=0
 EOM
 
-yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms nfs-utils
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms nfs-utils bzip2
 
 # Make ssh faster by not waiting on DNS
 echo "UseDNS no" >> /etc/ssh/sshd_config


### PR DESCRIPTION
This is needed push is needed for successfully installing the VirtualBox Guest Additions. I got some troubles when installing the guest additions in Version 4.3.18. After I added the package bzip2 everything works fine.
