### PR TITLE
Skip copy/chmod of disabled post install files

### DIFF
--- a/lib/veewee/provider/core/box/build.rb
+++ b/lib/veewee/provider/core/box/build.rb
@@ -257,6 +257,12 @@ module Veewee
           definition.postinstall_files.each do |postinstall_file|
             # Filenames of postinstall_files are relative to their definition
             filename=File.join(definition.path,postinstall_file)
+
+            if File.basename(postinstall_file).start_with?("_")
+              env.logger.info "Skipping copy of postinstallfile #{postinstall_file}"
+              next
+            end
+
             self.copy_to_box(filename,File.basename(filename))
             if not (definition.winrm_user && definition.winrm_password)
               self.exec("chmod +x \"#{File.basename(filename)}\"")


### PR DESCRIPTION
Currently, if you disable a postinstall_script by adding
an underscore, veewee will try to copy that file over with
and underscore in the name. Since the underscore is being
used to disable a post install script and not point to a
specific file, we should just skip copying disabled postinstall
scripts over since they will not be used.

If there is another way you think this should be handled I'm open
to ideas.  I'd rather not have to have 2 files _file.sh and file.sh for
disabled postinstall scripts to be enabled via --postinstall-include.
