### PR TITLE
Update installation.md

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,6 +1,7 @@
 # Veewee Installation
 
 Before installing Veewee, please see the [Requirements](requirements.md) doc.
+##### IMPORTANT: Currently supported versions of ruby: 2.0.0
 
 ## Install as a gem
 
@@ -55,7 +56,7 @@ Run `bundle install` to install Gemfile dependencies for our local gemset:
 
 With rbenv already installed (see [Requirements](requirements.md)), ensure a ruby version that's supported by Veewee is available on your machine:
 
-    $ rbenv install 1.9.2-p320
+    $ rbenv install 2.0.0-p598
     $ rbenv rehash
 
 Clone the veewee project from source:
@@ -66,7 +67,7 @@ Clone the veewee project from source:
 
 Set the local ruby version within the current directory:
 
-    $ rbenv local 1.9.2-p320
+    $ rbenv local 2.0.0-p598
     $ rbenv rehash
 
 Run `bundle install` to install Gemfile dependencies for our selected ruby version:

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,7 +1,7 @@
 # Veewee Installation
 
 Before installing Veewee, please see the [Requirements](requirements.md) doc.
-##### IMPORTANT: Currently supported versions of ruby: 2.0.0
+##### IMPORTANT: Currently supported versions of ruby: 2.2.0
 
 ## Install as a gem
 
@@ -56,7 +56,7 @@ Run `bundle install` to install Gemfile dependencies for our local gemset:
 
 With rbenv already installed (see [Requirements](requirements.md)), ensure a ruby version that's supported by Veewee is available on your machine:
 
-    $ rbenv install 2.0.0-p598
+    $ rbenv install 2.2.0
     $ rbenv rehash
 
 Clone the veewee project from source:
@@ -67,7 +67,7 @@ Clone the veewee project from source:
 
 Set the local ruby version within the current directory:
 
-    $ rbenv local 2.0.0-p598
+    $ rbenv local 2.2.0
     $ rbenv rehash
 
 Run `bundle install` to install Gemfile dependencies for our selected ruby version:


### PR DESCRIPTION
I've changed (would like to change) the ruby versions used in the documentation to reflect a more current ruby version.  1.9.2 refuses to compile at all on the latest version of OS X (Yosemite).  I've proposed 2.0.0-p598 because a) I've installed Veewee on an Ubuntu 12.04 machine and my OS X machine within the last 24 hours, and successfully built a box without any noticed ruby errors,  and b) I received advice on https://github.com/jedi4ever/veewee/issues/774 that seemed confident that 2.0.0 was the correct version supported by Veewee.

I've also stuck a h5 at the top of the doc to assert that this is the supported version (though have not included a patch number).

(I think it would also be good if the notes regarding v1.8.7 were removed completely but I don't have the information about who's using which versions of ruby).