### PR TITLE
Fix for VBox NAT interface address

### DIFF
--- a/lib/veewee/provider/virtualbox/box/helper/ip.rb
+++ b/lib/veewee/provider/virtualbox/box/helper/ip.rb
@@ -5,7 +5,11 @@ module Veewee
 
         # http://www.virtualbox.org/manual/ch09.html#idp13716288
         def host_ip_as_seen_by_guest
-          "10.0.2.2"
+          # as per definition in virtualbox 
+          # we need to add 1 because vboxmanage starts counting from 1 for display,
+          # but counts from 0 when actually assigning the IP
+          host_ip = "10.0.#{self.natinterface.to_i + 1}.2"
+          return host_ip # "10.0.2.2"
         end
 
         # Get the IP address of the box


### PR DESCRIPTION
Hi,

I wanted to be able to build a virtualbox vm and have 4 NICs attached to it. It turned out you can not by default do that because of the way VBox assigns IPs to NAT. If the NIC to get NAT is eth0 all is well and it works, but if it's eth3 it doesn't work anymore because veewee serves the kickstart on the wrong IP.

I only tested on my box by using 4 network card and changing the NAT one, from eth0 to eth3.