### PR TITLE
Add Oracle Linux 7.1 x86_64 template

### DIFF
--- a/templates/OracleLinux-7.1-x86_64-DVD/base.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/base.sh
@@ -1,0 +1,27 @@
+# Base install
+
+source ./proxy.sh
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+cd /tmp
+wget http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+rpm -ivh epel-release-7-5.noarch.rpm
+rm -f epel-release-7-5.noarch.rpm
+# Not flexible to switch between direct Internet access and behind firewall
+# --httpproxy HOST --httpport PORT
+# rpm -ivh http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+
+echo "UseDNS no" >> /etc/ssh/sshd_config
+
+hostnamectl set-hostname oraclelinux7.vagrant.vm
+
+yum-config-manager --enable ol7_optional_latest
+
+cat <<'EOF' > /etc/yum.repos.d/debuginfo.repo 
+[debuginfo]
+name=debuginfo
+baseurl=https://oss.oracle.com/ol7/debuginfo/
+gpgcheck=0
+enabled=1
+EOF

--- a/templates/OracleLinux-7.1-x86_64-DVD/chef.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+source ./proxy.sh
+curl -L https://www.opscode.com/chef/install.sh | bash

--- a/templates/OracleLinux-7.1-x86_64-DVD/cleanup.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/cleanup.sh
@@ -1,0 +1,11 @@
+# clean up orphaned packages
+package-cleanup --leaves | xargs yum erase -y
+
+yum -y clean all
+
+# rm -rf /etc/yum.repos.d/{puppetlabs,epel,epel-testing}.repo # keep
+rm -rf VBoxGuestAdditions_*.iso
+
+# Remove traces of mac address and uuid from network configuration
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-enp0s3
+sed -i /UUID/d /etc/sysconfig/network-scripts/ifcfg-enp0s3

--- a/templates/OracleLinux-7.1-x86_64-DVD/definition.rb
+++ b/templates/OracleLinux-7.1-x86_64-DVD/definition.rb
@@ -1,0 +1,40 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '480',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'Oracle_64',
+  :iso_file => "OracleLinux-R7-U1-Server-x86_64-dvd.iso",
+  :iso_src => "http://mirrors.dotsrc.org/oracle-linux/OL7/u1/x86_64/OracleLinux-R7-U1-Server-x86_64-dvd.iso",
+  :iso_md5 => "5728ef4b431d28a2d4ad62dbdf5bf36d",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 300,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "veewee",
+  :ssh_password => "veewee",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "proxy.sh",
+    "base.sh",
+    #"provision.sh",
+    "ruby.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/OracleLinux-7.1-x86_64-DVD/ks.cfg
+++ b/templates/OracleLinux-7.1-x86_64-DVD/ks.cfg
@@ -1,0 +1,60 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw vagrant
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+
+zerombr
+clearpart --all --initlabel
+autopart
+
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@core
+chrony
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+deltarpm
+vim
+yum-utils
+-libdtrace-ctf
+-libertas-sd8686-firmware
+-libertas-sd8787-firmware
+-libertas-usb8388-firmware
+%end
+
+%post --log=/root/ks-postinstall.log
+/usr/sbin/groupadd veewee
+/usr/sbin/useradd veewee -g veewee -G wheel
+echo "veewee" | passwd --stdin veewee
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+%end

--- a/templates/OracleLinux-7.1-x86_64-DVD/provision.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/provision.sh
@@ -1,0 +1,35 @@
+#!/bin/bash - 
+# Initial provisioning shell script
+# For CentOS and Oracle Linux 7
+
+echo $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
+
+# EPEL for Enterprise Linux 7 already set in base.sh
+# rpm -ivh http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+
+# Start provisioning
+yum install -y bash bash-completion zsh tmux \
+    wget curl gawk ack \
+    htop dstat iotop iftop sysstat psmisc \
+    git tig rsync sshfs sshpass \
+    vim colordiff \
+    pv tree expect \
+    ethtool iptraf nmap iperf3 \
+    iptables conntrack iptstate \
+    net-tools bind-utils \
+    lshw pciutils usbutils \
+    strace gdb \
+    reptyr ntsysv \
+    yum-utils
+
+ret=$?
+
+if [[ $ret -ne 0 ]]; then
+    echo "Unfortunately something went wrong..." >&2
+    exit 1
+else
+    echo "Shell script provisioning done!"
+    sudo yum clean all
+fi
+
+exit 0

--- a/templates/OracleLinux-7.1-x86_64-DVD/proxy.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/proxy.sh
@@ -1,0 +1,3 @@
+# Set proxy for machines behind firewall
+# export {http,https,ftp}_proxy=""
+# unset {http,https,ftp}_proxy

--- a/templates/OracleLinux-7.1-x86_64-DVD/puppet.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/puppet.sh
@@ -1,0 +1,15 @@
+# Install Puppet
+
+source ./proxy.sh
+
+cd /tmp
+
+# Missing libselinux-ruby package is available in ol7_optional_latest
+# enabled in base.sh
+
+# Enable the Puppet Labs Package Repository
+wget http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+rpm -Uvh puppetlabs-release-el-7.noarch.rpm
+rm -f /tmp/puppetlabs-release-el-7.noarch.rpm
+
+yum -y install puppet

--- a/templates/OracleLinux-7.1-x86_64-DVD/ruby.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/ruby.sh
@@ -1,0 +1,5 @@
+# Install Ruby
+
+source ./proxy.sh
+
+yum -y install ruby rubygems

--- a/templates/OracleLinux-7.1-x86_64-DVD/vagrant.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/vagrant.sh
@@ -1,0 +1,21 @@
+# Vagrant specific
+
+source ./proxy.sh
+
+date > /etc/vagrant_box_build_time
+
+# Add vagrant user
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant" | passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Customize the message of the day
+echo 'Welcome to Veewee built Vagrant Base Box.' > /etc/motd

--- a/templates/OracleLinux-7.1-x86_64-DVD/virtualbox.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/virtualbox.sh
@@ -1,0 +1,8 @@
+# Installing the virtualbox guest additions
+
+VBOX_VERSION=$(cat /home/veewee/.vbox_version)
+cd /tmp
+mount -o loop /home/veewee/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/veewee/VBoxGuestAdditions_*.iso

--- a/templates/OracleLinux-7.1-x86_64-DVD/zerodisk.sh
+++ b/templates/OracleLinux-7.1-x86_64-DVD/zerodisk.sh
@@ -1,0 +1,2 @@
+# Zero out the free space to save space in the final image:
+cat /dev/zero > /EMPTY; sync; sleep 3; sync; rm -f /EMPTY


### PR DESCRIPTION
Add new template for Oracle Linux 7.1 x86_64

Changes since issue #974 
- Added [debuginfo](https://oss.oracle.com/ol7/debuginfo/) as repository, see `base.sh`

Tested and confirmed to work ;-D
- Ruby 2.2.1 with `rbenv`
- VirtualBox 4.3.6
- veewee master branch

@jedi4ever Please merge ASAP.