### PR TITLE
Gentoo corrections and improvements

### DIFF
--- a/templates/gentoo-latest/definition.rb
+++ b/templates/gentoo-latest/definition.rb
@@ -13,5 +13,5 @@ template_build = Net::HTTP.get_response(URI.parse(template_uri)).body.split(/\n/
 
 Veewee::Definition.declare({
     :iso_file    => template_build.first.split(/\//).last,
-    :iso_src     => "http://distfiles.gentoo.org/releases/#{arch}/autobuilds/#{template_build.last}"
+    :iso_src     => "http://distfiles.gentoo.org/releases/#{arch}/autobuilds/#{template_build.first}"
 })

--- a/templates/gentoo-latest/ruby.sh
+++ b/templates/gentoo-latest/ruby.sh
@@ -2,8 +2,8 @@
 source /etc/profile
 
 cat <<DATAEOF >> "$chroot/etc/portage/make.conf"
-# use ruby 1.9
-RUBY_TARGETS="ruby19"
+# use ruby 2.0
+RUBY_TARGETS="ruby20"
 DATAEOF
 
 cat <<DATAEOF >> "$chroot/etc/portage/package.accept_keywords/ruby"
@@ -12,6 +12,6 @@ DATAEOF
 
 chroot "$chroot" /bin/bash <<DATAEOF
 env-update && source /etc/profile
-emerge --autounmask-write ruby:1.9
-eselect ruby set ruby19
+emerge --autounmask-write ruby:2.0
+eselect ruby set ruby20
 DATAEOF

--- a/templates/gentoo-latest/settings_amd64.sh
+++ b/templates/gentoo-latest/settings_amd64.sh
@@ -9,7 +9,7 @@ distfiles_url=http://distfiles.gentoo.org
 
 build_arch="amd64"
 build_proc="amd64"
-stage3current=\`curl -s \${distfiles_url}/releases/\${build_arch}/autobuilds/latest-stage3-\${build_proc}.txt|grep -v "^#"\`
+stage3current=\`curl -s \${distfiles_url}/releases/\${build_arch}/autobuilds/latest-stage3-\${build_proc}.txt|grep -v "^#"|grep -o "^\\S*"\`
 export stage3url="\${distfiles_url}/releases/\${build_arch}/autobuilds/\${stage3current}"
 export stage3file=\${stage3current##*/}
 export portageurl="\${distfiles_url}/snapshots/portage-latest.tar.bz2"
@@ -19,8 +19,8 @@ export accept_keywords="amd64"
 export chost="x86_64-pc-linux-gnu"
 
 # kernel version to use
-export kernel_version="3.14.14"
-export kernel_image_version="3.4.14-gentoo"
+export kernel_version="3.14.36"
+export kernel_image_version="3.14.36-gentoo"
 
 # timezone (as a subdirectory of /usr/share/zoneinfo)
 export timezone="UTC"

--- a/templates/gentoo-latest/settings_x86.sh
+++ b/templates/gentoo-latest/settings_x86.sh
@@ -9,7 +9,7 @@ distfiles_url=http://distfiles.gentoo.org
 
 build_arch="x86"
 build_proc="i686"
-stage3current=\`curl -s \${distfiles_url}/releases/\${build_arch}/autobuilds/latest-stage3-\${build_proc}.txt|grep -v "^#"\`
+stage3current=\`curl -s \${distfiles_url}/releases/\${build_arch}/autobuilds/latest-stage3-\${build_proc}.txt|grep -v "^#"|grep -o "^\\S*"\`
 export stage3url="\${distfiles_url}/releases/\${build_arch}/autobuilds/\${stage3current}"
 export stage3file=\${stage3current##*/}
 export portageurl="\${distfiles_url}/snapshots/portage-latest.tar.bz2"
@@ -19,8 +19,8 @@ export accept_keywords="x86"
 export chost="i686-pc-linux-gnu"
 
 # kernel version to use
-export kernel_version="3.14.14"
-export kernel_image_version="3.14.14-gentoo"
+export kernel_version="3.14.36"
+export kernel_image_version="3.14.36-gentoo"
 
 # timezone (as a subdirectory of /usr/share/zoneinfo)
 export timezone="UTC"

--- a/templates/gentoo-latest/wipe_sources.sh
+++ b/templates/gentoo-latest/wipe_sources.sh
@@ -6,5 +6,5 @@ chroot "$chroot" /bin/bash <<DATAEOF
 pushd /usr/src/linux
 make clean
 popd
-#emerge -C sys-kernel/gentoo-sources
+emerge -C sys-kernel/gentoo-sources
 DATAEOF


### PR DESCRIPTION
This pull request includes the following changes to the Gentoo template:
* **Correction tothe URL for downloading the Gentoo ISO** - The format of the text file the filename is retrieved from changed.
* **Ruby 2.0 is not installed instead of Ruby 1.9** - This is required to install Chef.
* **Corrections to the URL for downloading Stage3 file** - The format of the of text file for fetching the filename changed.
* **Updated Kernel version from 3.14.14 to 3.14.36** - The Kernel image version was also wrong for AMD64 architecture.
* **Uninstall Gentoo Sources as a part of the cleanup** - This has shaved 120MB from the resulting box size.