### PR TITLE
Add Oracle Linux 6.6 i386 & x86_64 templates

### DIFF
--- a/templates/OracleLinux-6.6-i386-DVD/base.sh
+++ b/templates/OracleLinux-6.6-i386-DVD/base.sh
@@ -1,0 +1,20 @@
+# Base install
+
+source ./proxy.sh
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+wget http://public-yum.oracle.com/public-yum-ol6.repo -O /etc/yum.repos.d/public-yum-ol6.repo
+# UEK R3 Latest Channel NOT enabled by default
+
+cd /tmp
+wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+rpm -ivh epel-release-6-8.noarch.rpm
+rm -f /tmp/epel-release-6-8.noarch.rpm
+# Not flexible to switch between direct Internet access and behind firewall
+# --httpproxy HOST --httpport PORT
+# rpm -ivh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+
+echo "UseDNS no" >> /etc/ssh/sshd_config
+
+sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network

--- a/templates/OracleLinux-6.6-i386-DVD/chef.sh
+++ b/templates/OracleLinux-6.6-i386-DVD/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+source ./proxy.sh
+curl -L https://www.opscode.com/chef/install.sh | bash

--- a/templates/OracleLinux-6.6-i386-DVD/cleanup.sh
+++ b/templates/OracleLinux-6.6-i386-DVD/cleanup.sh
@@ -1,0 +1,9 @@
+yum -y remove gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+
+# rm -rf /etc/yum.repos.d/{puppetlabs,epel,epel-testing}.repo # keep
+rm -rf VBoxGuestAdditions_*.iso
+
+# Remove traces of mac address from network configuration
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
+rm /etc/udev/rules.d/70-persistent-net.rules

--- a/templates/OracleLinux-6.6-i386-DVD/definition.rb
+++ b/templates/OracleLinux-6.6-i386-DVD/definition.rb
@@ -1,0 +1,39 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '480',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'Oracle',
+  :iso_file => "OracleLinux-R6-U6-Server-i386-dvd.iso",
+  :iso_src => "http://mirrors.dotsrc.org/oracle-linux/OL6/U6/i386/OracleLinux-R6-U6-Server-i386-dvd.iso",
+  :iso_md5 => "4aa4bac2477cf60991636918e0a87243",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "veewee",
+  :ssh_password => "veewee",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "proxy.sh",
+    "base.sh",
+    # "ruby.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/OracleLinux-6.6-i386-DVD/ks.cfg
+++ b/templates/OracleLinux-6.6-i386-DVD/ks.cfg
@@ -1,0 +1,56 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw vagrant
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+
+zerombr
+clearpart --all --initlabel
+autopart
+
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+yum-utils
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+
+%post --log=/root/ks-postinstall.log
+/usr/sbin/groupadd veewee
+/usr/sbin/useradd veewee -g veewee -G wheel
+echo "veewee" | passwd --stdin veewee
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+%end

--- a/templates/OracleLinux-6.6-i386-DVD/proxy.sh
+++ b/templates/OracleLinux-6.6-i386-DVD/proxy.sh
@@ -1,0 +1,6 @@
+# Set proxy for machines behind firewall
+# export http_proxy=""
+# export https_proxy=""
+# export ftp_proxy=""
+# All in one line
+# export {http,https,ftp}_proxy=""

--- a/templates/OracleLinux-6.6-i386-DVD/puppet.sh
+++ b/templates/OracleLinux-6.6-i386-DVD/puppet.sh
@@ -1,0 +1,10 @@
+# Install Puppet
+
+source ./proxy.sh
+
+cd /tmp
+wget http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+rpm -ivh puppetlabs-release-el-6.noarch.rpm
+rm -f /tmp/puppetlabs-release-el-6.noarch.rpm
+
+yum -y install puppet facter

--- a/templates/OracleLinux-6.6-i386-DVD/ruby.sh
+++ b/templates/OracleLinux-6.6-i386-DVD/ruby.sh
@@ -1,0 +1,5 @@
+# Install Ruby
+
+source ./proxy.sh
+
+yum -y install ruby ruby-devel rubygems

--- a/templates/OracleLinux-6.6-i386-DVD/vagrant.sh
+++ b/templates/OracleLinux-6.6-i386-DVD/vagrant.sh
@@ -1,0 +1,21 @@
+# Vagrant specific
+
+source ./proxy.sh
+
+date > /etc/vagrant_box_build_time
+
+# Add vagrant user
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant" | passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Customize the message of the day
+echo 'Welcome to Veewee built Vagrant Base Box.' > /etc/motd

--- a/templates/OracleLinux-6.6-i386-DVD/virtualbox.sh
+++ b/templates/OracleLinux-6.6-i386-DVD/virtualbox.sh
@@ -1,0 +1,8 @@
+# Installing the virtualbox guest additions
+
+VBOX_VERSION=$(cat /home/veewee/.vbox_version)
+cd /tmp
+mount -o loop /home/veewee/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/veewee/VBoxGuestAdditions_*.iso

--- a/templates/OracleLinux-6.6-i386-DVD/zerodisk.sh
+++ b/templates/OracleLinux-6.6-i386-DVD/zerodisk.sh
@@ -1,0 +1,3 @@
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/templates/OracleLinux-6.6-x86_64-DVD/base.sh
+++ b/templates/OracleLinux-6.6-x86_64-DVD/base.sh
@@ -1,0 +1,20 @@
+# Base install
+
+source ./proxy.sh
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+wget http://public-yum.oracle.com/public-yum-ol6.repo -O /etc/yum.repos.d/public-yum-ol6.repo
+# UEK R3 Latest Channel NOT enabled by default
+
+cd /tmp
+wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+rpm -ivh epel-release-6-8.noarch.rpm
+rm -f /tmp/epel-release-6-8.noarch.rpm
+# Not flexible to switch between direct Internet access and behind firewall
+# --httpproxy HOST --httpport PORT
+# rpm -ivh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+
+echo "UseDNS no" >> /etc/ssh/sshd_config
+
+sed -i "s/^HOSTNAME=.*/HOSTNAME=oracle.vagrantup.com/" /etc/sysconfig/network

--- a/templates/OracleLinux-6.6-x86_64-DVD/chef.sh
+++ b/templates/OracleLinux-6.6-x86_64-DVD/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+source ./proxy.sh
+curl -L https://www.opscode.com/chef/install.sh | bash

--- a/templates/OracleLinux-6.6-x86_64-DVD/cleanup.sh
+++ b/templates/OracleLinux-6.6-x86_64-DVD/cleanup.sh
@@ -1,0 +1,9 @@
+yum -y remove gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+
+# rm -rf /etc/yum.repos.d/{puppetlabs,epel,epel-testing}.repo # keep
+rm -rf VBoxGuestAdditions_*.iso
+
+# Remove traces of mac address from network configuration
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
+rm /etc/udev/rules.d/70-persistent-net.rules

--- a/templates/OracleLinux-6.6-x86_64-DVD/definition.rb
+++ b/templates/OracleLinux-6.6-x86_64-DVD/definition.rb
@@ -1,0 +1,39 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '480',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'Oracle_64',
+  :iso_file => "OracleLinux-R6-U6-Server-x86_64-dvd.iso",
+  :iso_src => "http://mirrors.dotsrc.org/oracle-linux/OL6/U6/x86_64/OracleLinux-R6-U6-Server-x86_64-dvd.iso",
+  :iso_md5 => "f88bd160b450c8df582e736fc502b3b5",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "veewee",
+  :ssh_password => "veewee",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "proxy.sh",
+    "base.sh",
+    # "ruby.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/OracleLinux-6.6-x86_64-DVD/ks.cfg
+++ b/templates/OracleLinux-6.6-x86_64-DVD/ks.cfg
@@ -1,0 +1,56 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw vagrant
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+
+zerombr
+clearpart --all --initlabel
+autopart
+
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@core
+wget
+curl
+make
+gcc
+gcc-c++
+kernel-devel
+kernel-uek-devel
+kernel-headers
+zlib-devel
+openssl-devel
+readline-devel
+sqlite-devel
+perl
+bzip2
+dkms
+net-tools
+bind-utils
+nfs-utils
+bash-completion
+yum-utils
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+
+%post --log=/root/ks-postinstall.log
+/usr/sbin/groupadd veewee
+/usr/sbin/useradd veewee -g veewee -G wheel
+echo "veewee" | passwd --stdin veewee
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+%end

--- a/templates/OracleLinux-6.6-x86_64-DVD/proxy.sh
+++ b/templates/OracleLinux-6.6-x86_64-DVD/proxy.sh
@@ -1,0 +1,6 @@
+# Set proxy for machines behind firewall
+# export http_proxy=""
+# export https_proxy=""
+# export ftp_proxy=""
+# All in one line
+# export {http,https,ftp}_proxy=""

--- a/templates/OracleLinux-6.6-x86_64-DVD/puppet.sh
+++ b/templates/OracleLinux-6.6-x86_64-DVD/puppet.sh
@@ -1,0 +1,10 @@
+# Install Puppet
+
+source ./proxy.sh
+
+cd /tmp
+wget http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+rpm -ivh puppetlabs-release-el-6.noarch.rpm
+rm -f /tmp/puppetlabs-release-el-6.noarch.rpm
+
+yum -y install puppet facter

--- a/templates/OracleLinux-6.6-x86_64-DVD/ruby.sh
+++ b/templates/OracleLinux-6.6-x86_64-DVD/ruby.sh
@@ -1,0 +1,5 @@
+# Install Ruby
+
+source ./proxy.sh
+
+yum -y install ruby ruby-devel rubygems

--- a/templates/OracleLinux-6.6-x86_64-DVD/vagrant.sh
+++ b/templates/OracleLinux-6.6-x86_64-DVD/vagrant.sh
@@ -1,0 +1,21 @@
+# Vagrant specific
+
+source ./proxy.sh
+
+date > /etc/vagrant_box_build_time
+
+# Add vagrant user
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant" | passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Customize the message of the day
+echo 'Welcome to Veewee built Vagrant Base Box.' > /etc/motd

--- a/templates/OracleLinux-6.6-x86_64-DVD/virtualbox.sh
+++ b/templates/OracleLinux-6.6-x86_64-DVD/virtualbox.sh
@@ -1,0 +1,8 @@
+# Installing the virtualbox guest additions
+
+VBOX_VERSION=$(cat /home/veewee/.vbox_version)
+cd /tmp
+mount -o loop /home/veewee/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/veewee/VBoxGuestAdditions_*.iso

--- a/templates/OracleLinux-6.6-x86_64-DVD/zerodisk.sh
+++ b/templates/OracleLinux-6.6-x86_64-DVD/zerodisk.sh
@@ -1,0 +1,3 @@
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY


### PR DESCRIPTION
Update Oracle Linux 6 templates to latest 6.6.

All have been tested and confirmed to work with veewee master branch + VirtualBox 4.3.26 on Linux x86_64.