### PR TITLE
archlinux-x86_64 Non-X.org VirtualBox Guest Additions

### DIFF
--- a/templates/archlinux-x86_64/virtualbox.sh
+++ b/templates/archlinux-x86_64/virtualbox.sh
@@ -7,7 +7,7 @@
 # Adapted from https://wiki.archlinux.org/index.php/VirtualBox
 
 # Install and set up VirtualBox Guest Additions
-pacman -S --noconfirm virtualbox-guest-utils
+pacman -S --noconfirm virtualbox-guest-utils-nox
 
 cat <<EOF > /etc/modules-load.d/virtualbox.conf
 vboxguest


### PR DESCRIPTION
This commit updates `virtualbox.sh` post install script for archlinux-x86_64
template to install VirtualBox Guest Additions without X.org requirements.

It installs `virtualbox-guest-utils-nox` package instead of
`virtualbox-guest-utils`, as the latter package pulls X.org and many other
packages as dependencies.