### PR TITLE
CentOS 7.1-1503 template

### DIFF
--- a/templates/CentOS-7.1-1503-x86_64-netinstall/base.sh
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/base.sh
@@ -1,0 +1,16 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=http://download.fedoraproject.org/pub/epel/beta/7/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms nfs-utils bzip2
+
+# Make ssh faster by not waiting on DNS
+echo "UseDNS no" >> /etc/ssh/sshd_config

--- a/templates/CentOS-7.1-1503-x86_64-netinstall/chef.sh
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/chef.sh
@@ -1,0 +1,2 @@
+# Install Chef
+curl -L https://www.opscode.com/chef/install.sh | bash

--- a/templates/CentOS-7.1-1503-x86_64-netinstall/cleanup.sh
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/cleanup.sh
@@ -1,0 +1,7 @@
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
+rm -rf VBoxGuestAdditions_*.iso
+
+# Remove traces of mac address from network configuration
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-enp0s3

--- a/templates/CentOS-7.1-1503-x86_64-netinstall/definition.rb
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/definition.rb
@@ -1,0 +1,38 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '480',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'RedHat6_64',
+  :iso_file => "CentOS-7-x86_64-NetInstall-1503.iso",
+  :iso_src => "http://mirror.nextlayer.at/centos/7/isos/x86_64/CentOS-7-x86_64-NetInstall-1503.iso",
+  :iso_md5 => "111379a06402e1e445c6aeee9401d031",
+  :iso_download_timeout => 1000,
+  :boot_wait => "10",
+  :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 300,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "veewee",
+  :ssh_password => "veewee",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    #"vmfusion.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/templates/CentOS-7.1-1503-x86_64-netinstall/ks.cfg
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/ks.cfg
@@ -1,0 +1,39 @@
+install
+url --url=http://mirror.nextlayer.at/centos/7/os/x86_64/
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --nobase
+@core
+bzip2
+openssh-clients
+openssh-server
+%end
+
+%post
+/usr/bin/yum -y install sudo
+/usr/sbin/groupadd veewee
+/usr/sbin/useradd veewee -g veewee -G wheel
+echo "veewee"|passwd --stdin veewee
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+%end
+

--- a/templates/CentOS-7.1-1503-x86_64-netinstall/puppet.sh
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/puppet.sh
@@ -1,0 +1,18 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/7/dependencies/\$basearch
+enabled=1
+gpgcheck=0
+
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/7/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter ruby-shadow
+

--- a/templates/CentOS-7.1-1503-x86_64-netinstall/vagrant.sh
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/vagrant.sh
@@ -1,0 +1,18 @@
+# Vagrant specific
+date > /etc/vagrant_box_build_time
+
+# Add vagrant user
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Customize the message of the day
+echo 'Welcome to your Vagrant-built virtual machine.' > /etc/motd

--- a/templates/CentOS-7.1-1503-x86_64-netinstall/virtualbox.sh
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/virtualbox.sh
@@ -1,0 +1,8 @@
+# Installing the virtualbox guest additions
+VBOX_VERSION=$(cat /home/veewee/.vbox_version)
+cd /tmp
+mount -o loop /home/veewee/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/veewee/VBoxGuestAdditions_*.iso
+

--- a/templates/CentOS-7.1-1503-x86_64-netinstall/vmfusion.sh
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/vmfusion.sh
@@ -1,0 +1,10 @@
+# vmware-vmblock-fuse requires libfuse.so
+yum -y install fuse-libs
+
+cd /tmp
+mkdir -p /mnt/cdrom
+mount -o loop /home/veewee/linux.iso /mnt/cdrom
+tar zxf /mnt/cdrom/VMwareTools-*.tar.gz -C /tmp/
+/tmp/vmware-tools-distrib/vmware-install.pl -d
+umount /mnt/cdrom
+rm /home/veewee/linux.iso

--- a/templates/CentOS-7.1-1503-x86_64-netinstall/zerodisk.sh
+++ b/templates/CentOS-7.1-1503-x86_64-netinstall/zerodisk.sh
@@ -1,0 +1,3 @@
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY


### PR DESCRIPTION
Validated under OS X 10.10.3 with VirtualBox 4.3.26. 

As an aside: this will probably break once a new release hits and 7.1 moves to the vault. That's what happened to 7.0.

Also, the old path to the Centos 7.0 iso (`http://mirror.nextlayer.at/centos/7.0.1406/`) is deprecated, see [this readme](http://mirror.nextlayer.at/centos/7.0.1406/readme). I suppose the 7.0 template should point to the [vault](http://vault.centos.org/7.0.1406/).