### PR TITLE
update Centos-7.0-1406 URLs

### DIFF
--- a/templates/CentOS-7.0-1406-x86_64-netinstall/definition.rb
+++ b/templates/CentOS-7.0-1406-x86_64-netinstall/definition.rb
@@ -6,7 +6,7 @@ Veewee::Session.declare({
   :hostiocache => 'off',
   :os_type_id => 'RedHat6_64',
   :iso_file => "CentOS-7.0-1406-x86_64-NetInstall.iso",
-  :iso_src => "http://mirror.nextlayer.at/centos/7.0.1406/isos/x86_64/CentOS-7.0-1406-x86_64-NetInstall.iso",
+  :iso_src => "http://mirror.nsc.liu.se/centos-store/7.0.1406/isos/x86_64/CentOS-7.0-1406-x86_64-NetInstall.iso",
   :iso_md5 => "96de4f38a2f07da51831153549c8bd0c",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/templates/CentOS-7.0-1406-x86_64-netinstall/ks.cfg
+++ b/templates/CentOS-7.0-1406-x86_64-netinstall/ks.cfg
@@ -1,5 +1,5 @@
 install
-url --url=http://mirror.nextlayer.at/centos/7.0.1406/os/x86_64/
+url --url=http://mirror.nsc.liu.se/centos-store/7.0.1406/os/x86_64/
 lang en_US.UTF-8
 keyboard us
 network --bootproto=dhcp


### PR DESCRIPTION
Validated under OS X 10.10.3 with VirtualBox 4.3.26. Updates the URLs to one of the mirrors from the vault.