### PR TITLE
Fixed Fission::Config

### DIFF
--- a/lib/fission/config.rb
+++ b/lib/fission/config.rb
@@ -24,11 +24,11 @@ module Fission
 
       fusion_version = :unknown
 
-      @attributes['vmrun_bin'] = %w{
-        /Library/Application Support/VMware Fusion/vmrun
-        /Applications/VMware Fusion.app/Contents/Library/vmrun
-        /usr/local/bin/vmrun
-      }.find { |path| File.exists?(path) }
+      @attributes['vmrun_bin'] = [
+        '/Library/Application Support/VMware Fusion/vmrun',
+        '/Applications/VMware Fusion.app/Contents/Library/vmrun',
+        '/usr/local/bin/vmrun'
+      ].find { |path| File.exists?(path) }
 
       if fusion_version == :unknown
       end


### PR DESCRIPTION
%w() splits by whitespace not newlines.

Veewee never finds `/Applications/VMware Fusion.app/Contents/Library/vmrun` because `File.exists?(path)` tests for `/Applications/VMware` and `Fusion.app/Contents/Library/vmrun`.