### PR TITLE
Fixes #1066 to include VirtualBox Windows2012_64 for Os Types

### DIFF
--- a/lib/veewee/config/ostypes.yml
+++ b/lib/veewee/config/ostypes.yml
@@ -29,6 +29,11 @@ Windows81_64:
   :kvm:
   :vbox: Windows81_64
   :parallels: win-8
+Windows2012_64:
+  :fusion: 
+  :kvm:
+  :vbox: Windows2012_64
+  :parallels: 
 WindowsNT:
   :fusion: winNT
   :kvm:


### PR DESCRIPTION
Fixes #1066 to include Windows2012_64 for Os Types