### PR TITLE
In Debian 6.0.10: Use LTS sources.list, run upgrade and dist-upgrade …

### DIFF
--- a/templates/Debian-6.0.10-amd64-netboot/base.sh
+++ b/templates/Debian-6.0.10-amd64-netboot/base.sh
@@ -1,8 +1,17 @@
+# Set sources.list to long term support repository.
+echo "deb http://httpredir.debian.org/debian/ squeeze main contrib non-free
+deb-src http://httpredir.debian.org/debian/ squeeze main contrib non-free
+deb http://httpredir.debian.org/debian squeeze-lts main contrib non-free
+deb-src http://httpredir.debian.org/debian squeeze-lts main contrib non-free" > /etc/apt/sources.list
+
 # Update the box
-apt-get -y update
-apt-get -y install linux-headers-$(uname -r) build-essential
-apt-get -y install zlib1g-dev libssl-dev libreadline5-dev
-apt-get -y install curl unzip
+export DEBIAN_FRONTEND="noninteractive"
+apt-get -qq update
+apt-get -qq upgrade
+apt-get -qq dist-upgrade
+apt-get -qq install linux-headers-$(uname -r) build-essential
+apt-get -qq install zlib1g-dev libssl-dev libreadline5-dev
+apt-get -qq install curl unzip
 apt-get clean
 
 # Set up sudo

--- a/templates/Debian-6.0.10-amd64-netboot/definition.rb
+++ b/templates/Debian-6.0.10-amd64-netboot/definition.rb
@@ -40,8 +40,8 @@ Veewee::Definition.declare({
     "virtualbox.sh",
     #"vmfusion.sh",
     "ruby.sh",
-    "puppet.sh",
-    "chef.sh",
+    #"puppet.sh",
+    #"chef.sh",
     "cleanup-virtualbox.sh",
     "cleanup.sh",
     "zerodisk.sh"

--- a/templates/Debian-6.0.10-amd64-netboot/preseed.cfg
+++ b/templates/Debian-6.0.10-amd64-netboot/preseed.cfg
@@ -1,7 +1,8 @@
 #### Contents of the preconfiguration file (for squeeze)
 ### Localization
 # Locale sets language and country.
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
+d-i localechooser/supported-locales en_US.UTF-8
 
 # Keyboard selection.
 #d-i console-tools/archs select at

--- a/templates/Debian-6.0.10-i386-netboot/base.sh
+++ b/templates/Debian-6.0.10-i386-netboot/base.sh
@@ -1,8 +1,17 @@
+# Set sources.list to long term support repository.
+echo "deb http://httpredir.debian.org/debian/ squeeze main contrib non-free
+deb-src http://httpredir.debian.org/debian/ squeeze main contrib non-free
+deb http://httpredir.debian.org/debian squeeze-lts main contrib non-free
+deb-src http://httpredir.debian.org/debian squeeze-lts main contrib non-free" > /etc/apt/sources.list
+
 # Update the box
-apt-get -y update
-apt-get -y install linux-headers-$(uname -r) build-essential
-apt-get -y install zlib1g-dev libssl-dev libreadline5-dev
-apt-get -y install curl unzip
+export DEBIAN_FRONTEND="noninteractive"
+apt-get -qq update
+apt-get -qq upgrade
+apt-get -qq dist-upgrade
+apt-get -qq install linux-headers-$(uname -r) build-essential
+apt-get -qq install zlib1g-dev libssl-dev libreadline5-dev
+apt-get -qq install curl unzip
 apt-get clean
 
 # Set up sudo

--- a/templates/Debian-6.0.10-i386-netboot/definition.rb
+++ b/templates/Debian-6.0.10-i386-netboot/definition.rb
@@ -40,8 +40,8 @@ Veewee::Definition.declare({
     "virtualbox.sh",
     #"vmfusion.sh",
     "ruby.sh",
-    "puppet.sh",
-    "chef.sh",
+    #"puppet.sh",
+    #"chef.sh",
     "cleanup-virtualbox.sh",
     "cleanup.sh",
     "zerodisk.sh"

--- a/templates/Debian-6.0.10-i386-netboot/preseed.cfg
+++ b/templates/Debian-6.0.10-i386-netboot/preseed.cfg
@@ -1,7 +1,8 @@
 #### Contents of the preconfiguration file (for squeeze)
 ### Localization
 # Locale sets language and country.
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
+d-i localechooser/supported-locales en_US.UTF-8
 
 # Keyboard selection.
 #d-i console-tools/archs select at


### PR DESCRIPTION
…after adding LTS sources, use en_US.UTF-8 locale to prevent warnings, comment out chef and puppet since they aren't needed by default.