### PR TITLE
Remove support for ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0
   - 2.1
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
-#if RUBY_VERSION =~ /1.9/
-    #Encoding.default_external = Encoding::UTF_8
-    #Encoding.default_internal = Encoding::UTF_8
-#end
-
 source "https://rubygems.org"
 
 #gem "veewee", :path => "."

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,7 +1,7 @@
 # Veewee Installation
 
 Before installing Veewee, please see the [Requirements](requirements.md) doc.
-Currently supported versions of ruby: `1.9.3` to `2.2.1`
+Currently supported versions of ruby: `2.0` and `2.1`
 ##### IMPORTANT: For best results, please use the latest version of Ruby.
 
 ## Install as a gem

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -43,7 +43,7 @@ On Windows, you will need to install:
 
 It is highly recommended that you use either `rvm` or `rbenv` to manage your ruby versions.
 
-Veewee currently supports Ruby version `1.9.3` to `2.2.1`
+Veewee currently supports Ruby version `2.0` and `2.1`
 IMPORTANT : For best results, please use the latest version of Ruby.
 
 

--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "os", "~> 0.9.6"
   s.add_dependency "gem-content", "~>1.0"
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0'
 
   # Modified dependency version, as libxml-ruby dependency has been removed in version 2.1.1
   # See : https://github.com/ckruse/CFPropertyList/issues/14

--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Vagrant box creation}
   s.description = %q{Expand the 'vagrant box' command to support the creation of base boxes from scratch}
 
-  s.required_rubygems_version = ">= 1.9.0"
+  s.required_rubygems_version = ">= 2.1.0"
   s.rubyforge_project         = "veewee"
 
 

--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Vagrant box creation}
   s.description = %q{Expand the 'vagrant box' command to support the creation of base boxes from scratch}
 
-  s.required_rubygems_version = ">= 1.3.6"
+  s.required_rubygems_version = ">= 1.9.0"
   s.rubyforge_project         = "veewee"
 
 


### PR DESCRIPTION
Ruby 1.9.3 has been EOL'd earlier this year. A lot of
veewee's gem requirements now require >= 2.x so its time
to remove support and testing of 1.9.3. 