### PR TITLE
Alpinelinux 3.6.2 x86 64 virtual template

### DIFF
--- a/templates/alpinelinux-3.6.2-x86_64-virtual/README.md
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/README.md
@@ -7,6 +7,7 @@ Minimal build of the 'Virtual'-Image.
 * The template currently only supports the VirtualBox provider
 * shutdown for vagrant is provided under /usr/local/bin
 * ``who`` and alike do not work because of [musl][] not providing utmp
+* if you want alpine-sdk with aports include ``aports.sh in`` in ``definition.rb``
 
 [musl]: http://wiki.musl-libc.org/wiki/FAQ#Q:_why_is_the_utmp.2Fwtmp_functionality_only_implemented_as_stubs_.3F
 # Alpine Linux

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/README.md
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/README.md
@@ -1,0 +1,12 @@
+# Alpine Linux
+
+Minimal build of the 'Virtual'-Image.
+
+## Note
+
+* The template currently only supports the VirtualBox provider
+* shutdown for vagrant is provided under /usr/local/bin
+* ``who`` and alike do not work because of [musl][] not providing utmp
+
+[musl]: http://wiki.musl-libc.org/wiki/FAQ#Q:_why_is_the_utmp.2Fwtmp_functionality_only_implemented_as_stubs_.3F
+# Alpine Linux

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/apk.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/apk.sh
@@ -1,0 +1,15 @@
+#!/bin/ash
+
+# Requires
+#   
+#   settings.sh
+#   base.sh
+#   sudo.sh
+#   user.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+sed -i '/v3.6\/community/s/^#//' /etc/apk/repositories
+apk update
+DATAEOF

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/aports.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/aports.sh
@@ -1,0 +1,29 @@
+#!/bin/ash
+
+# Requires
+#    settings.sh
+#    base.sh
+#    sudo.sh
+#    user.sh
+#    apk.sh
+#    virtualbox.sh
+#    vagrant.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+apk add alpine-sdk
+su - vagrant -c 'cd ~/ && git clone git://git.alpinelinux.org/aports'
+
+addgroup vagrant abuild
+
+mkdir -p /var/cache/distfiles
+chmod a+w /var/cache/distfiles
+chgrp abuild /var/cache/distfiles
+chmod g+w /var/cache/distfiles
+
+echo "Don't forget to run 'abuild-keygen -a -i'" >> /home/vagrant/README.ABUILD
+chown vagrant:vagrant /home/vagrant/README.ABUILD
+DATAEOF
+
+

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/base.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/base.sh
@@ -1,0 +1,77 @@
+#!/bin/ash
+
+# Requires
+#   settings.sh
+
+source /etc/profile
+
+# grsec will get in the way, disable it for the installation
+for i in $(sysctl -a | grep grsec | awk -F '=' '{print $1}'); do 
+	sysctl -w ${i}=0 
+done
+
+apk add e2fsprogs syslinux
+
+fdisk /dev/sda << EOF
+n
+p
+1
+
++100M
+a
+1
+n
+p
+2
+
+
+t
+2
+8e
+w
+EOF
+
+BOOT_DEV=/dev/sda1
+ROOT_DEV=/dev/sda2
+
+mkfs.ext4 $ROOT_DEV
+mkfs.ext4 $BOOT_DEV
+mount -t ext4 $ROOT_DEV /mnt
+mkdir /mnt/boot
+mount -t ext4 $BOOT_DEV /mnt/boot
+
+setup-disk -m sys /mnt
+dd bs=$(stat -c %s /mnt/usr/share/syslinux/mbr.bin) \
+   count=1 conv=notrunc \
+   if=/mnt/usr/share/syslinux/mbr.bin \
+   of=/dev/sda
+
+extlinux --install /mnt/boot
+
+# Prepare Chroot
+mount -t proc none "$chroot/proc"
+mount -t sysfs sys "$chroot/sys"
+mount --rbind /dev "$chroot/dev"
+cp /etc/resolv.conf "$chroot/etc/"
+date -u > "$chroot/etc/vagrant_box_build_time"
+
+chroot $chroot /bin/ash <<DATAEOF
+update-extlinux --warn-only
+
+cat <<EOF> /etc/network/interfaces
+auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet dhcp
+	hostname alpine
+EOF
+
+rc-update add networking boot
+rc-update add sshd default
+sed -i 's/PermitRootLogin/# PermitRootLogin/g' /etc/ssh/sshd_config
+setup-hostname alpine
+
+DATAEOF
+
+

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/chef.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/chef.sh
@@ -1,0 +1,21 @@
+#!/bin/ash
+
+# Requires
+#    settings.sh
+#    base.sh
+#    sudo.sh
+#    user.sh
+#    apk.sh
+#    virtualbox.sh
+#    ruby.sh
+#    vagrant.sh
+#    puppet.sh
+ 
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+apk add yajl-dev build-base libffi-dev ruby-io-console
+gem install chef --no-document
+DATAEOF
+
+

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/cleanup.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/cleanup.sh
@@ -1,0 +1,25 @@
+#!/bin/ash
+
+# Requires
+#    settings.sh
+#    base.sh
+#    sudo.sh
+#    user.sh
+#    apk.sh
+#    virtualbox.sh
+#    vagrant.sh
+#    ruby.sh
+#    puppet.sh
+#    chef.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<"DATAEOF"
+# Clean up
+unset HISTFILE
+[ -f /root/.bash_history ] && rm /root/.bash_history
+
+# Clean up logfiles
+find /var/log -type f | while read f; do echo -ne '' > $f; done
+
+DATAEOF

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/definition.rb
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/definition.rb
@@ -49,6 +49,7 @@ Veewee::Definition.declare({
     'apk.sh',
     'virtualbox.sh',
     'vagrant.sh',
+    # 'aports.sh',
     'ruby.sh',
     'puppet.sh',
     'chef.sh',

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/definition.rb
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/definition.rb
@@ -1,0 +1,63 @@
+require 'net/http'
+
+iso_name = 'alpine-virt-3.6.2-x86_64.iso'
+iso_mirror = 'http://dl-cdn.alpinelinux.org/alpine/v3.6/releases/x86_64'
+iso_uri = "#{iso_mirror}/#{iso_name}"
+check_sum = "#{iso_mirror}/#{iso_name}.sha256"
+
+root_password = 'veewee'
+
+Veewee::Definition.declare({
+  :cpu_count   => "1",
+  :memory_size => "256",
+  :disk_size   => "10140",
+  :disk_format => "VDI",
+  :hostiocache => "off",
+  :os_type_id  => "Linux26_64",
+  :iso_file    => iso_name,
+  :iso_src     => iso_uri,
+  :iso_sha256  => check_sum,
+  :iso_download_timeout => "1000",
+  :boot_wait   => "5",
+  :boot_cmd_sequence => [
+    '<Enter>',
+    '<Wait30>',
+    'root<Enter>',
+    'ifconfig eth0 up<Enter>',
+    'udhcpc eth0<Enter>',
+    'passwd<Enter>',
+    "#{root_password}<Enter>",
+    "#{root_password}<Enter>",
+    'setup-apkrepos -1<Enter>',
+    'apk add openssh<Enter>',
+    'echo "PermitRootLogin yes" >> /etc/ssh/sshd_config<Enter>',
+    '/etc/init.d/sshd start<Enter>',
+  ],
+  :ssh_login_timeout => "10000",
+  :ssh_user          => "root",
+  :ssh_password      => "#{root_password}",
+  :ssh_key           => "",
+  :ssh_host_port     => "7222",
+  :ssh_guest_port    => "22",
+  :sudo_cmd          => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd      => "poweroff",
+  :postinstall_files => [
+    'settings.sh',
+    'base.sh',
+    'sudo.sh',
+    'user.sh',
+    'apk.sh',
+    'virtualbox.sh',
+    'vagrant.sh',
+    'ruby.sh',
+    'puppet.sh',
+    'chef.sh',
+    'cleanup.sh',
+    'zerodisk.sh',
+    'reboot.sh',
+  ],
+  :postinstall_timeout => "10000",
+  :params => {
+    #:PACMAN_REFLECTOR_ARGS => '--verbose -l 5 --sort rate --save /etc/pacman.d/mirrorlist',
+  }
+})

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/puppet.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/puppet.sh
@@ -1,0 +1,20 @@
+#!/bin/ash
+
+# Requires
+#    settings.sh
+#    base.sh
+#    sudo.sh
+#    user.sh
+#    apk.sh
+#    virtualbox.sh
+#    vagrant.sh
+#    ruby.sh
+ 
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+apk add ruby-irb ruby-json
+gem install puppet --no-document
+DATAEOF
+
+

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/reboot.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/reboot.sh
@@ -1,0 +1,27 @@
+#!/bin/ash
+
+# Requires
+#    settings.sh
+#    base.sh
+#    sudo.sh
+#    user.sh
+#    apk.sh
+#    virtualbox.sh
+#    vagrant.sh
+#    ruby.sh
+#    puppet.sh
+#    chef.sh
+#    cleanup.sh
+#    zerodisk.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<"DATAEOF"
+# Delete all veewee related files that were copied over, including this script
+rm -rf /root/{*,.v*}
+DATAEOF
+
+# reboot, mainly to enable grsec again
+umount /mnt/boot
+umount -lf /mnt
+reboot

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/ruby.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/ruby.sh
@@ -1,0 +1,15 @@
+#!/bin/ash
+
+# Requires
+#    settings.sh
+#    base.sh
+#    sudo.sh
+#    user.sh
+#    apk.sh
+#    virtualbox.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+apk add ruby ruby-dev
+DATAEOF

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/settings.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/settings.sh
@@ -1,3 +1,5 @@
+#!/bin/ash
+
 # settings that will be shared between all scripts
 cat <<DATAEOF > "/etc/profile.d/veewee.sh"
 export chroot=/mnt

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/settings.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/settings.sh
@@ -1,0 +1,4 @@
+# settings that will be shared between all scripts
+cat <<DATAEOF > "/etc/profile.d/veewee.sh"
+export chroot=/mnt
+DATAEOF

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/sudo.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/sudo.sh
@@ -1,0 +1,17 @@
+#!/bin/ash
+
+# Requires
+#   base.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+
+apk add sudo
+
+cat <<EOF > /etc/sudoers
+root ALL=(ALL) ALL
+%wheel ALL=(ALL) NOPASSWD: ALL
+EOF
+
+DATAEOF

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/user.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/user.sh
@@ -1,0 +1,19 @@
+#!/bin/ash
+
+# Requires
+#   settings.sh
+#   base.sh
+#   sudo.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+
+adduser -h /home/veewee -G wheel -S -s /bin/ash veewee
+passwd -d veewee
+passwd veewee<<EOF
+veewee
+veewee
+EOF
+
+DATAEOF

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/vagrant.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/vagrant.sh
@@ -1,0 +1,50 @@
+#!/bin/ash
+
+# Requires
+#    settings.sh
+#    base.sh
+#    sudo.sh
+#    user.sh
+#    apk.sh
+#    virtualbox.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+
+adduser -h /home/vagrant -G wheel -S -s /bin/ash vagrant
+addgroup vagrant
+adduser vagrant vagrant
+adduser vagrant vboxsf
+
+passwd -d vagrant
+passwd vagrant<<EOF
+vagrant
+vagrant
+EOF
+
+mkdir -m 700 /home/vagrant/.ssh
+
+# alpine has no shutdown, provide one for vagrant halt
+
+cat <<EOF>/usr/local/bin/shutdown
+#!/bin/sh
+echo "This is just a call to poweroff..."
+poweroff
+EOF
+
+chmod +x /usr/local/bin/shutdown
+
+# add bash, because vagrant ssh checks the shell
+apk add curl bash
+
+curl -L 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' \
+  -o /home/vagrant/.ssh/authorized_keys
+
+chmod 600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /home/vagrant/.ssh
+
+apk add nfs-utils
+rc-update add rpc.statd default
+
+DATAEOF

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/virtualbox.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/virtualbox.sh
@@ -1,0 +1,29 @@
+#!/bin/ash
+
+# Requires
+#   
+#   settings.sh
+#   base.sh
+#   sudo.sh
+#   user.sh
+#   apk.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+
+apk add virtualbox-guest-modules-virthardened \
+	virtualbox-guest-additions
+
+cat <<EOF>> /etc/modules
+vboxpci
+vboxdrv
+vboxnetflt
+vboxsf
+EOF
+
+# For shared folders to work
+addgroup vboxsf
+addgroup veewee vboxsf
+
+DATAEOF

--- a/templates/alpinelinux-3.6.2-x86_64-virtual/zerodisk.sh
+++ b/templates/alpinelinux-3.6.2-x86_64-virtual/zerodisk.sh
@@ -1,0 +1,23 @@
+#!/bin/ash
+
+# Requires
+#    settings.sh
+#    base.sh
+#    sudo.sh
+#    user.sh
+#    apk.sh
+#    virtualbox.sh
+#    vagrant.sh
+#    ruby.sh
+#    puppet.sh
+#    chef.sh
+#    cleanup.sh
+
+source /etc/profile
+
+chroot $chroot /bin/ash <<DATAEOF
+
+# Zero out the free space to save space in the final image
+dd if=/dev/zero of=/tmp/clean bs=1M
+rm -f /tmp/clean
+DATAEOF


### PR DESCRIPTION
Provide a template for AlpineLinux-3.6.2-x86_64. The ``who am i``-Test fails, because Alpine Linux uses musl instead of glibc which does not implement utmp [(see here)](http://wiki.musl-libc.org/wiki/FAQ#Q:_why_is_the_utmp.2Fwtmp_functionality_only_implemented_as_stubs_.3F)