### PR TITLE
Explicit failure for arch64 template and use latest image

### DIFF
--- a/templates/archlinux-x86_64/base.sh
+++ b/templates/archlinux-x86_64/base.sh
@@ -36,7 +36,7 @@ arch-chroot /mnt <<ENDCHROOT
 # Automatic interface selection
 # If ssh hangs and cannot reconnect, comment this line and uncomment the
 # two following ones.
-systemctl enable dhcpcd\@$(ip addr show label 'en*' | head -1 | cut -d' ' -f2 | sed 's/://').service
+systemctl enable dhcpcd\@$(cd /sys/class/net/; ls -d en* | head -n1).service
 
 # Manual interface selection by disabling systemd's Predictable Network Interface Names
 # Uncomment the two following lines if automatic detection didn't work.

--- a/templates/archlinux-x86_64/definition.rb
+++ b/templates/archlinux-x86_64/definition.rb
@@ -2,7 +2,11 @@ require 'net/http'
 
 iso_mirror = 'http://mirrors.kernel.org/archlinux/iso/2015.03.01'
 uri = "#{iso_mirror}/md5sums.txt"
-response = Net::HTTP.get_response(URI.parse(uri)).body.split
+response = Net::HTTP.get_response(URI.parse(uri))
+if response.code != '200' then
+  fail "Could not download from #{uri}: [#{response.code}] #{response}"
+end
+response = response.body.split
 iso = response[1]
 iso_md5 = response[0]
 

--- a/templates/archlinux-x86_64/definition.rb
+++ b/templates/archlinux-x86_64/definition.rb
@@ -1,6 +1,6 @@
 require 'net/http'
 
-iso_mirror = 'http://mirrors.kernel.org/archlinux/iso/2015.03.01'
+iso_mirror = 'https://mirrors.edge.kernel.org/archlinux/iso/latest/'
 uri = "#{iso_mirror}/md5sums.txt"
 response = Net::HTTP.get_response(URI.parse(uri))
 if response.code != '200' then

--- a/templates/archlinux-x86_64/ssh.sh
+++ b/templates/archlinux-x86_64/ssh.sh
@@ -13,6 +13,9 @@ echo "sshd:	ALL" > /etc/hosts.allow
 # And everything else isn't
 echo "ALL:	ALL" > /etc/hosts.deny
 
+# Needed to ssh after reboot
+sed -i 's/#PermitRootLogin.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+
 # Make sure sshd starts on boot
 systemctl enable sshd.service
 ENDCHROOT


### PR DESCRIPTION
Because archlinux changed its repo location, the current md5 uri
returns a 301 moved permanently message. Then using .body.split on it
made the iso and iso_md5 variables be nil. And then veewee choked on
that.

Before this commit, this is the actual message you get in this case:
```
$ bundle exec veewee vbox build -w myarch

Downloading vbox guest additions iso v 5.2.18 - http://download.virtualbox.org/virtualbox/5.2.18/VBoxGuestAdditions_5.2.18.iso
Checking if isofile VBoxGuestAdditions_5.2.18.iso already exists.
Full path: veewee/iso/VBoxGuestAdditions_5.2.18.iso

The isofile VBoxGuestAdditions_5.2.18.iso already exists.
Building Box mesh with Definition mesh:
- debug : false
- cwd : veewee/
- force : false
- nogui : false
- auto : false
- checksum : false
- redirectconsole : false
- postinstall_include : []
- postinstall_exclude : []
- skip_to_postinstall : false
bundler: failed to load command: veewee (~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/bin/veewee)
TypeError: no implicit conversion of nil into String
  ~/veewee/lib/veewee/provider/core/helper/iso.rb:113:in `join'
  ~/veewee/lib/veewee/provider/core/helper/iso.rb:113:in `verify_iso'
  ~/veewee/lib/veewee/provider/core/box/build.rb:101:in `build'
  ~/veewee/lib/veewee/provider/virtualbox/box/build.rb:10:in `build'
  ~/veewee/lib/veewee/command/vbox.rb:22:in `build'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/thor-0.20.0/lib/thor/invocation.rb:115:in `invoke'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/thor-0.20.0/lib/thor.rb:238:in `block in subcommand'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
  ~/tmp/veewee/bin/veewee:24:in `<top (required)>'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/bin/veewee:23:in `load'
  ~/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/bin/veewee:23:in `<top (required)>'
```

The first commit actually makes the error message explicit:

```
  Could not instantiate the box mesh with provider Virtualbox ,Error in the definition from file veewee/definitions/mesh/definition.rb
  Could not download from http://mirrors.kernel.org/archlinux/iso/latest/md5sums.txt: [301] #<Net::HTTPMovedPermanently:0x007fe277b9e9c8>
  Error in the definition from file veewee/definitions/mesh/definition.rb
  Could not download from http://mirrors.kernel.org/archlinux/iso/latest/md5sums.txt: [301] #<Net::HTTPMovedPermanently:0x007fe277b9e9c8>
```

And the second commit switches to the correct new base uri and uses also the latest image always now.

The last two commits were needed to successfully have a base image.