### PR TITLE
suppress deprecation message

### DIFF
--- a/lib/veewee/provider/core/helper/ssh.rb
+++ b/lib/veewee/provider/core/helper/ssh.rb
@@ -222,7 +222,7 @@ module Veewee::Provider::Core::Helper::Ssh
     options=defaults.merge(options)
     options={
       :auth_methods => %w[ password publickey keyboard-interactive ],
-      :paranoid => false
+      :verify_host_key => :never
     }.merge(options)
     options=Hash[ options.select { |key, value| Net::SSH::VALID_OPTIONS.include?(key) } ]
     Net::SSH.start( host, options[:user], options ) do |ssh|

--- a/lib/veewee/provider/core/helper/winrm.rb
+++ b/lib/veewee/provider/core/helper/winrm.rb
@@ -103,7 +103,7 @@ module Veewee
 
 
           def winrm_transfer_file(host,filename,destination = '.' , options = {})
-            options = winrm_options.merge(options.merge({:paranoid => false }))
+            options = winrm_options.merge(options.merge({:verify_host_name => :never }))
             # when_winrm_login_works
 
             env.ui.info "FIXME: Transferring #{filename} to #{destination} "

--- a/lib/veewee/provider/core/provider/tunnel.rb
+++ b/lib/veewee/provider/core/provider/tunnel.rb
@@ -7,9 +7,9 @@ module Veewee
 
 
       def ssh_tunnel_start(forwardings)
-        #ssh_options={ :keys => [ vm.private_key ], :paranoid => false, :keys_only => true}
+        #ssh_options={ :keys => [ vm.private_key ], :verify_host_key => :never, :keys_only => true }
 
-        ssh_options={ :paranoid => false}
+        ssh_options={ :verify_host_key => :never }
         host=@connection.uri.host
         user=@connection.uri.user
 


### PR DESCRIPTION
An update in net/ssh changed the option `:paranoid => False` to `:verify_host_key => :never`. This clutters the output with a lot of depreciation notice:
```
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
verify_host_key: false is deprecated, use :never
```
This PR uses the new variable name and value.

See https://github.com/hashicorp/vagrant/issues/9062.